### PR TITLE
avoid running CI twice on pull requests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,9 @@
 name: Build Mac, Linux, and Windows wheels
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main, dev ]
+  pull_request:
 
 jobs:
   build_wheels:


### PR DESCRIPTION
@hoffmang9 did you make the change deliberately to trigger CI twice for pull requests? The commit message said "On all push or pull", but the change was "On all push **and** pull", i.e. since every pull request also is a push, it's run twice.