### PR TITLE
simplify the complex lifetime relationship between allocator and SExp

### DIFF
--- a/src/int_allocator.rs
+++ b/src/int_allocator.rs
@@ -37,6 +37,7 @@ impl IntAllocator {
 
 impl Allocator for IntAllocator {
     type Ptr = u32;
+    type AtomBuf = u32;
 
     fn new_atom(&self, v: &[u8]) -> u32 {
         let index = self.u8_vec.len() as u32;
@@ -52,12 +53,20 @@ impl Allocator for IntAllocator {
         r
     }
 
-    fn sexp<'a: 'c, 'b: 'c, 'c>(&'a self, node: &'b u32) -> SExp<'c, u32> {
+    fn atom<'a>(&'a self, node: &'a Self::Ptr) -> &'a [u8] {
         match self.node_vec[*node as usize] {
-            NodePtr::Atom(index) => {
-                let atom = &self.u8_vec[index as usize];
-                SExp::Atom(&atom)
-            }
+            NodePtr::Atom(index) => &self.u8_vec[index as usize],
+            _ => panic!("expected atom, got pair"),
+        }
+    }
+
+    fn buf<'a>(&'a self, node: &'a Self::AtomBuf) -> &'a [u8] {
+        &self.u8_vec[*node as usize]
+    }
+
+    fn sexp(&self, node: &Self::Ptr) -> SExp<Self::Ptr, Self::AtomBuf> {
+        match self.node_vec[*node as usize] {
+            NodePtr::Atom(index) => SExp::Atom(index),
             NodePtr::Pair(left, right) => SExp::Pair(left, right),
         }
     }

--- a/src/py/arc_allocator.rs
+++ b/src/py/arc_allocator.rs
@@ -43,18 +43,30 @@ impl ArcAllocator {
 
 impl Allocator for ArcAllocator {
     type Ptr = ArcSExp;
+    type AtomBuf = Arc<Vec<u8>>;
 
     fn new_atom(&self, v: &[u8]) -> ArcSExp {
         ArcSExp::Atom(Arc::new(v.into()))
     }
 
     fn new_pair(&self, first: ArcSExp, rest: ArcSExp) -> ArcSExp {
-        ArcSExp::Pair(Arc::new(first.to_owned()), Arc::new(rest.to_owned()))
+        ArcSExp::Pair(Arc::new(first), Arc::new(rest))
     }
 
-    fn sexp<'a: 'c, 'b: 'c, 'c>(&'a self, node: &'b ArcSExp) -> SExp<'c, ArcSExp> {
+    fn atom<'a>(&'a self, node: &'a Self::Ptr) -> &'a [u8] {
         match node {
-            ArcSExp::Atom(atom) => SExp::Atom(&atom),
+            ArcSExp::Atom(a) => &*a,
+            _ => panic!("expected atom, got pair"),
+        }
+    }
+
+    fn buf<'a>(&'a self, node: &'a Self::AtomBuf) -> &'a [u8] {
+        &*node
+    }
+
+    fn sexp(&self, node: &ArcSExp) -> SExp<ArcSExp, Arc<Vec<u8>>> {
+        match node {
+            ArcSExp::Atom(a) => SExp::Atom(a.clone()),
             ArcSExp::Pair(left, right) => {
                 let p1: &ArcSExp = &left;
                 let p2: &ArcSExp = &right;
@@ -80,9 +92,10 @@ impl Default for ArcAllocator {
     }
 }
 
-impl<P> dyn Allocator<Ptr = P>
+impl<P, B> dyn Allocator<Ptr = P, AtomBuf = B>
 where
     P: Clone,
+    B: Clone,
 {
     pub fn err<T>(&self, node: &P, msg: &str) -> Result<T, EvalErr<P>> {
         Err(EvalErr(node.clone(), msg.into()))

--- a/src/py/glue.rs
+++ b/src/py/glue.rs
@@ -74,7 +74,11 @@ where
                 let r: PyResult<PyObject> = pre_eval.call1(py, (program_clone, args));
                 match r {
                     Ok(py_post_eval) => Ok(post_eval_for_pyobject::<A>(py, py_post_eval)),
-                    Err(ref err) => (allocator as &dyn Allocator<Ptr = <A as Allocator>::Ptr>)
+                    Err(ref err) => (allocator
+                        as &dyn Allocator<
+                            Ptr = <A as Allocator>::Ptr,
+                            AtomBuf = <A as Allocator>::AtomBuf,
+                        >)
                         .err(program, &err.to_string()),
                 }
             })

--- a/src/py/py_node.rs
+++ b/src/py/py_node.rs
@@ -122,12 +122,13 @@ impl PyNode {
 
     #[getter(atom)]
     pub fn atom(&self, py: Python) -> Option<PyObject> {
-        match ArcAllocator::new().sexp(&self.node) {
-            SExp::Atom(a) => {
+        let alloc = ArcAllocator::new();
+        match alloc.sexp(&self.node) {
+            SExp::Atom(atom) => {
                 {
                     let mut borrowed_bytes = self.pyobj.borrow_mut();
                     if borrowed_bytes.is_none() {
-                        let b: &PyBytes = PyBytes::new(py, a);
+                        let b: &PyBytes = PyBytes::new(py, alloc.buf(&atom));
                         let obj: PyObject = b.into();
                         *borrowed_bytes = Some(obj);
                     };

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -52,7 +52,8 @@ pub fn node_to_stream<T: Allocator>(node: &Node<T>, f: &mut dyn Write) -> std::i
         let v = values.pop().unwrap();
         let n = a.sexp(&v);
         match n {
-            SExp::Atom(atom) => {
+            SExp::Atom(atom_ptr) => {
+                let atom = a.buf(&atom_ptr);
                 let size = atom.len();
                 if size == 0 {
                     f.write_all(&[0x80_u8])?;


### PR DESCRIPTION
Instead, ask the allocator to get the underlying bytes for an atom every time. Some of the complication here comes from the fact that the `ArcAllocator` has the `T::Ptr` own the bytes, whereas the `IntAllocator` has the allocator itself own the bytes. It especially makes it a bit tricky to unify in `Node::atom()`, that needs to return bytes whose lifetime is tied to the allocator.

Being able to break the ownership ties of a node and the allocator is important to be able to make the allocator honor mutability (i.e. make the allocating functions require a mutable allocator).

With mutable allocators, a function cannot hold an `SExp<>` (prior to this patch) when attempting to allocate a new node or pair. This is problematic because the only way to determine whether a node is a pair or an atom is to call `sexp()`, which then "burns" a reference to the allocator that cannot be undone because of the current ownership transfer.

This patch allows to break the ownership tie, and hold a mutable reference to the allocator within the match-expression.