### PR TITLE
Replace Aovec with Vec

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -13,8 +13,8 @@ pub trait Allocator {
     type Ptr: Clone;
     type AtomBuf: Clone;
 
-    fn new_atom(&self, v: &[u8]) -> Self::Ptr;
-    fn new_pair(&self, first: Self::Ptr, rest: Self::Ptr) -> Self::Ptr;
+    fn new_atom(&mut self, v: &[u8]) -> Self::Ptr;
+    fn new_pair(&mut self, first: Self::Ptr, rest: Self::Ptr) -> Self::Ptr;
 
     // The lifetime here is a bit special because IntAllocator and ArcAllocator
     // have slightly different requirements. With IntAllocator, all buffers are

--- a/src/core_ops.rs
+++ b/src/core_ops.rs
@@ -11,7 +11,7 @@ const LISTP_COST: u32 = 5;
 const CMP_BASE_COST: u32 = 16;
 const CMP_COST_PER_LIMB_DIVIDER: u32 = 64;
 
-pub fn op_if<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+pub fn op_if<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
     let args = Node::new(a, input);
     check_arg_count(&args, 3, "i")?;
     let cond = args.first()?;
@@ -22,7 +22,7 @@ pub fn op_if<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
     Ok(Reduction(IF_COST, chosen_node.first()?.node))
 }
 
-pub fn op_cons<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+pub fn op_cons<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
     let args = Node::new(a, input);
     check_arg_count(&args, 2, "c")?;
     let a1 = args.first()?;
@@ -33,19 +33,19 @@ pub fn op_cons<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
     Ok(Reduction(CONS_COST, r))
 }
 
-pub fn op_first<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+pub fn op_first<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
     let args = Node::new(a, input);
     check_arg_count(&args, 1, "f")?;
     Ok(Reduction(FIRST_COST, args.first()?.first()?.node))
 }
 
-pub fn op_rest<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+pub fn op_rest<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
     let args = Node::new(a, input);
     check_arg_count(&args, 1, "r")?;
     Ok(Reduction(REST_COST, args.first()?.rest()?.node))
 }
 
-pub fn op_listp<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+pub fn op_listp<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
     let args = Node::new(a, input);
     check_arg_count(&args, 1, "l")?;
     match args.first()?.pair() {
@@ -54,12 +54,12 @@ pub fn op_listp<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
     }
 }
 
-pub fn op_raise<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+pub fn op_raise<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
     let args = Node::new(a, input);
     args.err("clvm raise")
 }
 
-pub fn op_eq<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+pub fn op_eq<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
     let args = Node::new(a, input);
     check_arg_count(&args, 2, "=")?;
     let a0 = args.first()?;

--- a/src/core_ops.rs
+++ b/src/core_ops.rs
@@ -11,8 +11,9 @@ const LISTP_COST: u32 = 5;
 const CMP_BASE_COST: u32 = 16;
 const CMP_COST_PER_LIMB_DIVIDER: u32 = 64;
 
-pub fn op_if<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
-    check_arg_count(args, 3, "i")?;
+pub fn op_if<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
+    check_arg_count(&args, 3, "i")?;
     let cond = args.first()?;
     let mut chosen_node = args.rest()?;
     if cond.nullp() {
@@ -21,49 +22,50 @@ pub fn op_if<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
     Ok(Reduction(IF_COST, chosen_node.first()?.node))
 }
 
-pub fn op_cons<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
-    check_arg_count(args, 2, "c")?;
+pub fn op_cons<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
+    check_arg_count(&args, 2, "c")?;
     let a1 = args.first()?;
     let a2 = args.rest()?.first()?;
-    let r = args.allocator.new_pair(a1.node, a2.node);
+    let n1 = a1.node;
+    let n2 = a2.node;
+    let r = a.new_pair(n1, n2);
     Ok(Reduction(CONS_COST, r))
 }
 
-pub fn op_first<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
-    check_arg_count(args, 1, "f")?;
+pub fn op_first<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
+    check_arg_count(&args, 1, "f")?;
     Ok(Reduction(FIRST_COST, args.first()?.first()?.node))
 }
 
-pub fn op_rest<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
-    check_arg_count(args, 1, "r")?;
+pub fn op_rest<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
+    check_arg_count(&args, 1, "r")?;
     Ok(Reduction(REST_COST, args.first()?.rest()?.node))
 }
 
-pub fn op_listp<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
-    check_arg_count(args, 1, "l")?;
+pub fn op_listp<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
+    check_arg_count(&args, 1, "l")?;
     match args.first()?.pair() {
-        Some((_first, _rest)) => Ok(Reduction(LISTP_COST, args.one().node)),
-        _ => Ok(Reduction(LISTP_COST, args.null().node)),
+        Some((_first, _rest)) => Ok(Reduction(LISTP_COST, a.one())),
+        _ => Ok(Reduction(LISTP_COST, a.null())),
     }
 }
 
-pub fn op_raise<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_raise<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     args.err("clvm raise")
 }
 
-pub fn op_eq<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
-    check_arg_count(args, 2, "=")?;
+pub fn op_eq<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
+    check_arg_count(&args, 2, "=")?;
     let a0 = args.first()?;
     let a1 = args.rest()?.first()?;
     let s0 = atom(&a0, "=")?;
     let s1 = atom(&a1, "=")?;
     let cost: u32 = CMP_BASE_COST + (s0.len() as u32 + s1.len() as u32) / CMP_COST_PER_LIMB_DIVIDER;
-    Ok(Reduction(
-        cost,
-        if s0 == s1 {
-            args.one().node
-        } else {
-            args.null().node
-        },
-    ))
+    Ok(Reduction(cost, if s0 == s1 { a.one() } else { a.null() }))
 }

--- a/src/err_utils.rs
+++ b/src/err_utils.rs
@@ -7,8 +7,10 @@ pub fn err<T, P>(node: P, msg: &str) -> Result<T, EvalErr<P>> {
 
 pub fn u8_err<A: Allocator, T>(
     allocator: &A,
-    node: &[u8],
+    o: &A::AtomBuf,
     msg: &str,
 ) -> Result<T, EvalErr<A::Ptr>> {
-    err(allocator.new_atom(node), msg)
+    let op = allocator.buf(&o);
+    let buf = op.to_vec();
+    err(allocator.new_atom(&buf), msg)
 }

--- a/src/err_utils.rs
+++ b/src/err_utils.rs
@@ -6,7 +6,7 @@ pub fn err<T, P>(node: P, msg: &str) -> Result<T, EvalErr<P>> {
 }
 
 pub fn u8_err<A: Allocator, T>(
-    allocator: &A,
+    allocator: &mut A,
     o: &A::AtomBuf,
     msg: &str,
 ) -> Result<T, EvalErr<A::Ptr>> {

--- a/src/int_allocator.rs
+++ b/src/int_allocator.rs
@@ -1,7 +1,5 @@
 use std::vec;
 
-use aovec::Aovec;
-
 use crate::allocator::{Allocator, SExp};
 
 enum NodePtr {
@@ -10,8 +8,8 @@ enum NodePtr {
 }
 
 pub struct IntAllocator {
-    u8_vec: Aovec<Vec<u8>>,
-    node_vec: Aovec<NodePtr>,
+    u8_vec: Vec<Vec<u8>>,
+    node_vec: Vec<NodePtr>,
 }
 
 impl Default for IntAllocator {
@@ -22,9 +20,9 @@ impl Default for IntAllocator {
 
 impl IntAllocator {
     pub fn new() -> Self {
-        let r = IntAllocator {
-            u8_vec: Aovec::new(1024 * 1024),
-            node_vec: Aovec::new(32768),
+        let mut r = IntAllocator {
+            u8_vec: Vec::new(),
+            node_vec: Vec::new(),
         };
         r.u8_vec.push(vec![]);
         r.u8_vec.push(vec![1_u8]);
@@ -38,7 +36,7 @@ impl Allocator for IntAllocator {
     type Ptr = u32;
     type AtomBuf = u32;
 
-    fn new_atom(&self, v: &[u8]) -> u32 {
+    fn new_atom(&mut self, v: &[u8]) -> u32 {
         let index = self.u8_vec.len() as u32;
         self.u8_vec.push(v.into());
         let r: u32 = self.node_vec.len() as u32;
@@ -46,7 +44,7 @@ impl Allocator for IntAllocator {
         r
     }
 
-    fn new_pair(&self, first: Self::Ptr, rest: Self::Ptr) -> Self::Ptr {
+    fn new_pair(&mut self, first: Self::Ptr, rest: Self::Ptr) -> Self::Ptr {
         let r: u32 = self.node_vec.len() as u32;
         self.node_vec.push(NodePtr::Pair(first, rest));
         r

--- a/src/int_allocator.rs
+++ b/src/int_allocator.rs
@@ -36,6 +36,7 @@ impl IntAllocator {
 
 impl Allocator for IntAllocator {
     type Ptr = u32;
+    type AtomBuf = u32;
 
     fn new_atom(&self, v: &[u8]) -> u32 {
         let index = self.u8_vec.len() as u32;
@@ -51,12 +52,20 @@ impl Allocator for IntAllocator {
         r
     }
 
-    fn sexp<'a: 'c, 'b: 'c, 'c>(&'a self, node: &'b u32) -> SExp<'c, u32> {
+    fn atom<'a>(&'a self, node: &'a Self::Ptr) -> &'a [u8] {
         match self.node_vec[*node as usize] {
-            NodePtr::Atom(index) => {
-                let atom = &self.u8_vec[index as usize];
-                SExp::Atom(&atom)
-            }
+            NodePtr::Atom(index) => &self.u8_vec[index as usize],
+            _ => panic!("expected atom, got pair"),
+        }
+    }
+
+    fn buf<'a>(&'a self, node: &'a Self::AtomBuf) -> &'a [u8] {
+        &self.u8_vec[*node as usize]
+    }
+
+    fn sexp(&self, node: &Self::Ptr) -> SExp<Self::Ptr, Self::AtomBuf> {
+        match self.node_vec[*node as usize] {
+            NodePtr::Atom(index) => SExp::Atom(index),
             NodePtr::Pair(left, right) => SExp::Pair(left, right),
         }
     }

--- a/src/more_ops.rs
+++ b/src/more_ops.rs
@@ -10,7 +10,7 @@ use lazy_static::lazy_static;
 use crate::allocator::Allocator;
 use crate::err_utils::u8_err;
 use crate::node::Node;
-use crate::number::{node_from_number, number_from_u8, Number};
+use crate::number::{number_from_u8, ptr_from_number, Number};
 use crate::op_utils::{atom, check_arg_count, int_atom, two_ints, uint_int};
 use crate::reduction::{Reduction, Response};
 use crate::serialize::node_to_bytes;
@@ -119,7 +119,7 @@ fn test_u32_from_u8() {
     assert_eq!(u32_from_u8(&[0x7d, 0xcc, 0x55, 0x88, 0xf3]), None);
 }
 
-pub fn op_unknown<A: Allocator>(op: &[u8], args: &Node<A>) -> Response<A::Ptr> {
+pub fn op_unknown<A: Allocator>(op: &[u8], allocator: &A, args: A::Ptr) -> Response<A::Ptr> {
     // unknown opcode in lenient mode
     // unknown ops are reserved if they start with 0xffff
     // otherwise, unknown ops are no-ops, but they have costs. The cost is computed
@@ -148,8 +148,6 @@ pub fn op_unknown<A: Allocator>(op: &[u8], args: &Node<A>) -> Response<A::Ptr> {
     // this means that unknown ops where cost_function is 1, 2, or 3, may still be
     // fatal errors if the arguments passed are not atoms.
 
-    let allocator = args.allocator;
-
     if op.is_empty() || (op.len() >= 2 && op[0] == 0xff && op[1] == 0xff) {
         return u8_err(allocator, op, "reserved operator");
     }
@@ -167,7 +165,7 @@ pub fn op_unknown<A: Allocator>(op: &[u8], args: &Node<A>) -> Response<A::Ptr> {
         1 => {
             let mut cost = ARITH_BASE_COST as u64;
             let mut byte_count: u64 = 0;
-            for arg in args {
+            for arg in Node::new(allocator, args) {
                 cost += ARITH_COST_PER_ARG as u64;
                 let blob = int_atom(&arg, "unknown op")?;
                 byte_count += blob.len() as u64;
@@ -178,7 +176,7 @@ pub fn op_unknown<A: Allocator>(op: &[u8], args: &Node<A>) -> Response<A::Ptr> {
             let mut cost = MUL_BASE_COST as u64;
             let mut first_iter: bool = true;
             let mut l0: u64 = 0;
-            for arg in args {
+            for arg in Node::new(allocator, args) {
                 let blob = int_atom(&arg, "unknown op")?;
                 if first_iter {
                     l0 = blob.len() as u64;
@@ -196,7 +194,7 @@ pub fn op_unknown<A: Allocator>(op: &[u8], args: &Node<A>) -> Response<A::Ptr> {
         3 => {
             let mut cost = CONCAT_BASE_COST as u64;
             let mut total_size: u64 = 0;
-            for arg in args {
+            for arg in Node::new(allocator, args) {
                 cost += CONCAT_COST_PER_ARG as u64;
                 let blob = atom(&arg, "unknown op")?;
                 total_size += blob.len() as u64;
@@ -227,38 +225,33 @@ fn test_unknown_op_reserved() {
 
     // any op starting with ffff is reserved and a hard failure
     let buf = vec![0xff, 0xff];
-    assert!(!op_unknown(&buf, &Node::new(&a, a.null())).is_ok());
+    let null = a.null();
+    assert!(!op_unknown(&buf, &a, null).is_ok());
 
     let buf = vec![0xff, 0xff, 0xff];
-    assert!(!op_unknown(&buf, &Node::new(&a, a.null())).is_ok());
+    assert!(!op_unknown(&buf, &a, null).is_ok());
 
     let buf = vec![0xff, 0xff, '0' as u8];
-    assert!(!op_unknown(&buf, &Node::new(&a, a.null())).is_ok());
+    assert!(!op_unknown(&buf, &a, null).is_ok());
 
     let buf = vec![0xff, 0xff, 0];
-    assert!(!op_unknown(&buf, &Node::new(&a, a.null())).is_ok());
+    assert!(!op_unknown(&buf, &a, null).is_ok());
 
     let buf = vec![0xff, 0xff, 0xcc, 0xcc, 0xfe, 0xed, 0xce];
-    assert!(!op_unknown(&buf, &Node::new(&a, a.null())).is_ok());
+    assert!(!op_unknown(&buf, &a, null).is_ok());
 
     // an empty atom is not a valid opcode
     let buf = Vec::<u8>::new();
-    assert!(!op_unknown(&buf, &Node::new(&a, a.null())).is_ok());
+    assert!(!op_unknown(&buf, &a, null).is_ok());
 
     // a single ff is not sufficient to be treated as a reserved opcode
     let buf = vec![0xff];
-    assert_eq!(
-        op_unknown(&buf, &Node::new(&a, a.null())),
-        Ok(Reduction(4, a.null()))
-    );
+    assert_eq!(op_unknown(&buf, &a, null), Ok(Reduction(4, null)));
 
     // leading zeros count, so this is not considered an ffff-prefix
     let buf = vec![0x00, 0xff, 0xff, 0x00, 0x00];
     // the cost is 0xffff00 = 16776960 plus the implied 1
-    assert_eq!(
-        op_unknown(&buf, &Node::new(&a, a.null())),
-        Ok(Reduction(16776961, a.null()))
-    );
+    assert_eq!(op_unknown(&buf, &a, null), Ok(Reduction(16776961, null)));
 }
 
 #[test]
@@ -267,66 +260,55 @@ fn test_lenient_mode_last_bits() {
 
     // the last 6 bits are ignored for computing cost
     let buf = vec![0x3c, 0x3f];
-    assert_eq!(
-        op_unknown(&buf, &Node::new(&a, a.null())),
-        Ok(Reduction(61, a.null()))
-    );
+    let null = a.null();
+    assert_eq!(op_unknown(&buf, &a, null), Ok(Reduction(61, null)));
 
     let buf = vec![0x3c, 0x0f];
-    assert_eq!(
-        op_unknown(&buf, &Node::new(&a, a.null())),
-        Ok(Reduction(61, a.null()))
-    );
+    assert_eq!(op_unknown(&buf, &a, null), Ok(Reduction(61, null)));
 
     let buf = vec![0x3c, 0x00];
-    assert_eq!(
-        op_unknown(&buf, &Node::new(&a, a.null())),
-        Ok(Reduction(61, a.null()))
-    );
+    assert_eq!(op_unknown(&buf, &a, null), Ok(Reduction(61, null)));
 
     let buf = vec![0x3c, 0x2c];
-    assert_eq!(
-        op_unknown(&buf, &Node::new(&a, a.null())),
-        Ok(Reduction(61, a.null()))
-    );
+    assert_eq!(op_unknown(&buf, &a, null), Ok(Reduction(61, null)));
 }
 
-pub fn op_sha256<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_sha256<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
     let mut cost: u32 = SHA256_BASE_COST;
     let mut byte_count: u32 = 0;
     let mut hasher = Sha256::new();
-    for arg in args {
+    for arg in Node::new(a, input) {
         cost += SHA256_COST_PER_ARG;
         let blob = atom(&arg, "sha256")?;
         byte_count += blob.len() as u32;
         hasher.input(blob);
     }
     cost += byte_count / SHA256_COST_PER_BYTE_DIVIDER;
-    Ok(Reduction(cost, args.new_atom(&hasher.result()).node))
+    Ok(Reduction(cost, a.new_atom(&hasher.result())))
 }
 
-pub fn op_add<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_add<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
     let mut cost: u32 = ARITH_BASE_COST;
     let mut byte_count: u32 = 0;
     let mut total: Number = 0.into();
-    for arg in args {
+    for arg in Node::new(a, input) {
         cost += ARITH_COST_PER_ARG;
         let blob = int_atom(&arg, "+")?;
         let v: Number = number_from_u8(&blob);
         byte_count += blob.len() as u32;
         total += v;
     }
-    let total: Node<T> = node_from_number(&args, &total);
+    let total = ptr_from_number(a, &total);
     cost += byte_count / ARITH_COST_PER_LIMB_DIVIDER;
-    Ok(Reduction(cost, total.node))
+    Ok(Reduction(cost, total))
 }
 
-pub fn op_subtract<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_subtract<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
     let mut cost: u32 = ARITH_BASE_COST;
     let mut byte_count: u32 = 0;
     let mut total: Number = 0.into();
     let mut is_first = true;
-    for arg in args {
+    for arg in Node::new(a, input) {
         cost += ARITH_COST_PER_ARG;
         let blob = int_atom(&arg, "-")?;
         let v: Number = number_from_u8(&blob);
@@ -338,17 +320,17 @@ pub fn op_subtract<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
         };
         is_first = false;
     }
-    let total: Node<T> = node_from_number(&args, &total);
+    let total = ptr_from_number(a, &total);
     cost += byte_count / ARITH_COST_PER_LIMB_DIVIDER;
-    Ok(Reduction(cost, total.node))
+    Ok(Reduction(cost, total))
 }
 
-pub fn op_multiply<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_multiply<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
     let mut cost: u32 = MUL_BASE_COST;
     let mut first_iter: bool = true;
     let mut total: Number = 1.into();
     let mut l0: u32 = 0;
-    for arg in args {
+    for arg in Node::new(a, input) {
         let blob = int_atom(&arg, "*")?;
         if first_iter {
             l0 = blob.len() as u32;
@@ -366,12 +348,13 @@ pub fn op_multiply<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
 
         l0 = limbs_for_int(&total);
     }
-    let total: Node<T> = node_from_number(&args, &total);
-    Ok(Reduction(cost, total.node))
+    let total = ptr_from_number(a, &total);
+    Ok(Reduction(cost, total))
 }
 
-pub fn op_div<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
-    let (a0, l0, a1, l1) = two_ints(args, "div")?;
+pub fn op_div<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
+    let (a0, l0, a1, l1) = two_ints(&args, "div")?;
     let cost = DIV_BASE_COST + (l0 + l1) / DIV_COST_PER_LIMB_DIVIDER;
     if a1.sign() == Sign::NoSign {
         args.first()?.err("div with 0")
@@ -386,13 +369,14 @@ pub fn op_div<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
         } else {
             q
         };
-        let q1: Node<T> = node_from_number(&args, &q);
-        Ok(Reduction(cost, q1.node))
+        let q1 = ptr_from_number(a, &q);
+        Ok(Reduction(cost, q1))
     }
 }
 
-pub fn op_divmod<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
-    let (a0, l0, a1, l1) = two_ints(args, "divmod")?;
+pub fn op_divmod<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
+    let (a0, l0, a1, l1) = two_ints(&args, "divmod")?;
     let cost = DIVMOD_BASE_COST + (l0 + l1) / DIVMOD_COST_PER_LIMB_DIVIDER;
     if a1.sign() == Sign::NoSign {
         args.first()?.err("divmod with 0")
@@ -410,14 +394,15 @@ pub fn op_divmod<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
         } else {
             (q, r)
         };
-        let q1: Node<T> = node_from_number(&args, &q);
-        let r1: Node<T> = node_from_number(&args, &r);
-        let r: T::Ptr = args.allocator.new_pair(q1.node, r1.node);
+        let q1 = ptr_from_number(a, &q);
+        let r1 = ptr_from_number(a, &r);
+        let r: T::Ptr = a.new_pair(q1, r1);
         Ok(Reduction(cost, r))
     }
 }
 
-pub fn op_gr<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_gr<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     check_arg_count(&args, 2, ">")?;
     let a0 = args.first()?;
     let a1 = args.rest()?.first()?;
@@ -427,42 +412,38 @@ pub fn op_gr<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
     Ok(Reduction(
         cost,
         if number_from_u8(v0) > number_from_u8(v1) {
-            args.one().node
+            a.one()
         } else {
-            args.null().node
+            a.null()
         },
     ))
 }
 
-pub fn op_gr_bytes<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_gr_bytes<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     check_arg_count(&args, 2, ">s")?;
     let a0 = args.first()?;
     let a1 = args.rest()?.first()?;
     let v0 = atom(&a0, ">s")?;
     let v1 = atom(&a1, ">s")?;
     let cost = CMP_BASE_COST + (v0.len() + v1.len()) as u32 / CMP_COST_PER_LIMB_DIVIDER;
-    Ok(Reduction(
-        cost,
-        if v0 > v1 {
-            args.one().node
-        } else {
-            args.null().node
-        },
-    ))
+    Ok(Reduction(cost, if v0 > v1 { a.one() } else { a.null() }))
 }
 
-pub fn op_strlen<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_strlen<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     check_arg_count(&args, 1, "strlen")?;
     let a0 = args.first()?;
     let v0 = atom(&a0, "strlen")?;
     let size: u32 = v0.len() as u32;
     let size_num: Number = size.into();
-    let size_node = node_from_number(&args, &size_num).node;
+    let size_node = ptr_from_number(a, &size_num);
     let cost: u32 = STRLEN_BASE_COST + size / STRLEN_COST_PER_BYTE_DIVIDER;
     Ok(Reduction(cost, size_node))
 }
 
-pub fn op_substr<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_substr<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     check_arg_count(&args, 3, "substr")?;
     let a0 = args.first()?;
     let s0 = atom(&a0, "substr")?;
@@ -475,16 +456,19 @@ pub fn op_substr<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
     } else {
         let u1: usize = i1 as usize;
         let u2: usize = i2 as usize;
-        let r = args.new_atom(&s0[u1..u2]).node;
+        let buf = s0[u1..u2].to_vec();
+        // TODO: extend allocator interface to support substr directly
+        let r = a.new_atom(&buf);
         let cost = 1;
         Ok(Reduction(cost, r))
     }
 }
 
-pub fn op_concat<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_concat<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     let mut cost: u32 = CONCAT_BASE_COST;
     let mut total_size: usize = 0;
-    for arg in args {
+    for arg in &args {
         cost += CONCAT_COST_PER_ARG;
         let blob = atom(&arg, "concat")?;
         total_size += blob.len();
@@ -496,13 +480,13 @@ pub fn op_concat<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
         v.extend_from_slice(blob);
     }
     cost += (total_size as u32) / CONCAT_COST_PER_BYTE_DIVIDER;
-    let allocator: &T = args.allocator;
-    let r: T::Ptr = allocator.new_atom(&v);
+    let r: T::Ptr = a.new_atom(&v);
 
     Ok(Reduction(cost, r))
 }
 
-pub fn op_ash<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_ash<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     let (i0, l0, i1, _) = two_ints(&args, "ash")?;
     let s1 = i64::try_from(&i1);
     if match s1 {
@@ -515,12 +499,13 @@ pub fn op_ash<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
     let a1 = s1.unwrap();
     let v: Number = if a1 > 0 { i0 << a1 } else { i0 >> -a1 };
     let l1 = limbs_for_int(&v);
-    let r: Node<T> = node_from_number(&args, &v);
+    let r = ptr_from_number(a, &v);
     let cost = SHIFT_BASE_COST + (l0 + l1) / SHIFT_COST_PER_BYTE_DIVIDER;
-    Ok(Reduction(cost, r.node))
+    Ok(Reduction(cost, r))
 }
 
-pub fn op_lsh<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_lsh<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     let (i0, l0, i1, _) = uint_int(&args, "lsh")?;
     let s1 = i64::try_from(&i1);
     if match s1 {
@@ -534,21 +519,22 @@ pub fn op_lsh<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
     let i0: Number = i0.into();
     let v: Number = if a1 > 0 { i0 << a1 } else { i0 >> -a1 };
     let l1 = limbs_for_int(&v);
-    let r: Node<T> = node_from_number(&args, &v);
+    let r = ptr_from_number(a, &v);
     let cost = SHIFT_BASE_COST + (l0 + l1) / SHIFT_COST_PER_BYTE_DIVIDER;
-    Ok(Reduction(cost, r.node))
+    Ok(Reduction(cost, r))
 }
 
 fn binop_reduction<T: Allocator>(
     op_name: &str,
+    a: &T,
     initial_value: Number,
-    args: &Node<T>,
+    input: T::Ptr,
     op_f: fn(&mut Number, &Number) -> (),
 ) -> Response<T::Ptr> {
     let mut total = initial_value;
     let mut arg_size = 0;
     let mut cost = LOG_BASE_COST;
-    for arg in args {
+    for arg in Node::new(a, input) {
         let blob = int_atom(&arg, op_name)?;
         let n0 = number_from_u8(blob);
         op_f(&mut total, &n0);
@@ -556,59 +542,62 @@ fn binop_reduction<T: Allocator>(
         cost += LOG_COST_PER_ARG;
     }
     cost += arg_size / LOG_COST_PER_LIMB_DIVIDER;
-    let total: Node<T> = node_from_number(&args, &total);
-    Ok(Reduction(cost, total.node))
+    let total = ptr_from_number(a, &total);
+    Ok(Reduction(cost, total))
 }
 
 fn logand_op<T: Allocator>(a: &mut Number, b: &Number) {
     a.bitand_assign(b);
 }
 
-pub fn op_logand<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_logand<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
     let v: Number = (-1).into();
-    binop_reduction("logand", v, args, logand_op::<T>)
+    binop_reduction("logand", a, v, input, logand_op::<T>)
 }
 
 fn logior_op<T: Allocator>(a: &mut Number, b: &Number) {
     a.bitor_assign(b);
 }
 
-pub fn op_logior<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_logior<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
     let v: Number = (0).into();
-    binop_reduction("logior", v, args, logior_op::<T>)
+    binop_reduction("logior", a, v, input, logior_op::<T>)
 }
 
 fn logxor_op<T: Allocator>(a: &mut Number, b: &Number) {
     a.bitxor_assign(b);
 }
 
-pub fn op_logxor<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_logxor<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
     let v: Number = (0).into();
-    binop_reduction("logxor", v, args, logxor_op::<T>)
+    binop_reduction("logxor", a, v, input, logxor_op::<T>)
 }
 
-pub fn op_lognot<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_lognot<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     check_arg_count(&args, 1, "lognot")?;
     let a0 = args.first()?;
     let v0 = int_atom(&a0, "lognot")?;
     let mut n: Number = number_from_u8(&v0);
     n = !n;
     let cost: u32 = LOGNOT_BASE_COST + (v0.len() as u32) / LOGNOT_COST_PER_BYTE_DIVIDER;
-    let r: Node<T> = node_from_number(&args, &n);
-    Ok(Reduction(cost, r.node))
+    let r = ptr_from_number(a, &n);
+    Ok(Reduction(cost, r))
 }
 
-pub fn op_not<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_not<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     check_arg_count(&args, 1, "not")?;
     let r: T::Ptr = args.from_bool(!args.first()?.as_bool()).node;
     let cost: u32 = BOOL_BASE_COST + BOOL_COST_PER_ARG;
     Ok(Reduction(cost, r))
 }
 
-pub fn op_any<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_any<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     let mut cost: u32 = BOOL_BASE_COST;
     let mut is_any = false;
-    for arg in args {
+    for arg in &args {
         cost += BOOL_COST_PER_ARG;
         is_any = is_any || arg.as_bool();
     }
@@ -616,10 +605,11 @@ pub fn op_any<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
     Ok(Reduction(cost, total.node))
 }
 
-pub fn op_all<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_all<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     let mut cost: u32 = BOOL_BASE_COST;
     let mut is_all = true;
-    for arg in args {
+    for arg in &args {
         cost += BOOL_COST_PER_ARG;
         is_all = is_all && arg.as_bool();
     }
@@ -627,7 +617,8 @@ pub fn op_all<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
     Ok(Reduction(cost, total.node))
 }
 
-pub fn op_softfork<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_softfork<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     match args.pair() {
         Some((p1, _)) => {
             let n: Number = number_from_u8(int_atom(&p1, "softfork")?);
@@ -673,7 +664,8 @@ fn number_to_scalar(n: Number) -> Scalar {
     }
 }
 
-pub fn op_pubkey_for_exp<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_pubkey_for_exp<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     check_arg_count(&args, 1, "pubkey_for_exp")?;
     let a0 = args.first()?;
 
@@ -683,15 +675,15 @@ pub fn op_pubkey_for_exp<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
     let exp: Scalar = number_to_scalar(exp);
     let point: G1Projective = G1Affine::generator() * exp;
     let point: G1Affine = point.into();
-    let point_node: Node<T> = args.new_atom(&point.to_compressed());
 
-    Ok(Reduction(cost, point_node.node))
+    Ok(Reduction(cost, a.new_atom(&point.to_compressed())))
 }
 
-pub fn op_point_add<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
+pub fn op_point_add<T: Allocator>(a: &T, input: T::Ptr) -> Response<T::Ptr> {
+    let args = Node::new(a, input);
     let mut cost: u32 = POINT_ADD_BASE_COST;
     let mut total: G1Projective = G1Projective::identity();
-    for arg in args {
+    for arg in &args {
         let blob = atom(&arg, "point_add")?;
         let mut is_ok: bool = blob.len() == 48;
         if is_ok {
@@ -712,6 +704,5 @@ pub fn op_point_add<T: Allocator>(args: &Node<T>) -> Response<T::Ptr> {
         }
     }
     let total: G1Affine = total.into();
-    let total: Node<T> = args.new_atom(&total.to_compressed());
-    Ok(Reduction(cost, total.node))
+    Ok(Reduction(cost, a.new_atom(&total.to_compressed())))
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -11,10 +11,6 @@ impl<'a, T: Allocator> Node<'a, T> {
         Node { allocator, node }
     }
 
-    pub fn new_atom(&self, v: &[u8]) -> Self {
-        self.with_node(self.allocator.new_atom(v))
-    }
-
     pub fn with_node(&self, node: T::Ptr) -> Self {
         Node::new(self.allocator, node)
     }

--- a/src/number.rs
+++ b/src/number.rs
@@ -4,7 +4,7 @@ use crate::node::Node;
 use num_bigint::BigInt;
 pub type Number = BigInt;
 
-pub fn ptr_from_number<T: Allocator>(allocator: &T, item: &Number) -> T::Ptr {
+pub fn ptr_from_number<T: Allocator>(allocator: &mut T, item: &Number) -> T::Ptr {
     let bytes: Vec<u8> = item.to_signed_bytes_be();
     let mut slice = bytes.as_slice();
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -4,10 +4,6 @@ use crate::node::Node;
 use num_bigint::BigInt;
 pub type Number = BigInt;
 
-pub fn node_from_number<'a, T: Allocator>(node: &'a Node<'a, T>, item: &Number) -> Node<'a, T> {
-    Node::new(node.allocator, ptr_from_number(node.allocator, item))
-}
-
 pub fn ptr_from_number<T: Allocator>(allocator: &T, item: &Number) -> T::Ptr {
     let bytes: Vec<u8> = item.to_signed_bytes_be();
     let mut slice = bytes.as_slice();

--- a/src/py/api.rs
+++ b/src/py/api.rs
@@ -68,13 +68,21 @@ fn py_run_program(
     op_lookup: Py<NativeOpLookup>,
     pre_eval: PyObject,
 ) -> PyResult<(u32, NodeClass)> {
-    let allocator = allocator_for_py(py);
+    let mut allocator = allocator_for_py(py);
     let op_lookup: &PyCell<NativeOpLookup> = op_lookup.as_ref(py);
     let op_lookup: PyRef<NativeOpLookup> = op_lookup.borrow();
     let op_lookup: Box<GenericNativeOpLookup<AllocatorT, NodeClass>> =
         Box::new(op_lookup.gnol(py).to_owned());
     _py_run_program(
-        py, &allocator, program, args, quote_kw, apply_kw, max_cost, op_lookup, pre_eval,
+        py,
+        &mut allocator,
+        program,
+        args,
+        quote_kw,
+        apply_kw,
+        max_cost,
+        op_lookup,
+        pre_eval,
     )
 }
 
@@ -100,8 +108,8 @@ fn allocator_for_py(_py: Python) -> AllocatorT {
 
 #[pyfunction]
 fn serialize_from_bytes(py: Python, blob: &[u8]) -> NodeClass {
-    let allocator = allocator_for_py(py);
-    _serialize_from_bytes(&allocator, blob)
+    let mut allocator = allocator_for_py(py);
+    _serialize_from_bytes(&mut allocator, blob)
 }
 
 #[pyfunction]

--- a/src/py/arc_allocator.rs
+++ b/src/py/arc_allocator.rs
@@ -42,6 +42,7 @@ impl ArcAllocator {
 
 impl Allocator for ArcAllocator {
     type Ptr = ArcSExp;
+    type AtomBuf = Arc<Vec<u8>>;
 
     fn new_atom(&self, v: &[u8]) -> ArcSExp {
         ArcSExp::Atom(Arc::new(v.into()))
@@ -51,9 +52,20 @@ impl Allocator for ArcAllocator {
         ArcSExp::Pair(Arc::new(first), Arc::new(rest))
     }
 
-    fn sexp<'a: 'c, 'b: 'c, 'c>(&'a self, node: &'b ArcSExp) -> SExp<'c, ArcSExp> {
+    fn atom<'a>(&'a self, node: &'a Self::Ptr) -> &'a [u8] {
         match node {
-            ArcSExp::Atom(atom) => SExp::Atom(&atom),
+            ArcSExp::Atom(a) => &*a,
+            _ => panic!("expected atom, got pair"),
+        }
+    }
+
+    fn buf<'a>(&'a self, node: &'a Self::AtomBuf) -> &'a [u8] {
+        &*node
+    }
+
+    fn sexp(&self, node: &ArcSExp) -> SExp<ArcSExp, Arc<Vec<u8>>> {
+        match node {
+            ArcSExp::Atom(a) => SExp::Atom(a.clone()),
             ArcSExp::Pair(left, right) => {
                 let p1: &ArcSExp = &left;
                 let p2: &ArcSExp = &right;

--- a/src/py/arc_allocator.rs
+++ b/src/py/arc_allocator.rs
@@ -34,7 +34,7 @@ impl ArcAllocator {
         ArcAllocator {}
     }
 
-    pub fn blob(&self, v: &str) -> ArcSExp {
+    pub fn blob(&mut self, v: &str) -> ArcSExp {
         let v: Vec<u8> = v.into();
         self.new_atom(&v)
     }
@@ -44,11 +44,11 @@ impl Allocator for ArcAllocator {
     type Ptr = ArcSExp;
     type AtomBuf = Arc<Vec<u8>>;
 
-    fn new_atom(&self, v: &[u8]) -> ArcSExp {
+    fn new_atom(&mut self, v: &[u8]) -> ArcSExp {
         ArcSExp::Atom(Arc::new(v.into()))
     }
 
-    fn new_pair(&self, first: ArcSExp, rest: ArcSExp) -> ArcSExp {
+    fn new_pair(&mut self, first: ArcSExp, rest: ArcSExp) -> ArcSExp {
         ArcSExp::Pair(Arc::new(first), Arc::new(rest))
     }
 

--- a/src/py/f_table.rs
+++ b/src/py/f_table.rs
@@ -7,7 +7,7 @@ use crate::more_ops::{
 };
 use crate::reduction::Response;
 
-type OpFn<T> = fn(&T, <T as Allocator>::Ptr) -> Response<<T as Allocator>::Ptr>;
+type OpFn<T> = fn(&mut T, <T as Allocator>::Ptr) -> Response<<T as Allocator>::Ptr>;
 
 pub type FLookup<T> = [Option<OpFn<T>>; 256];
 

--- a/src/py/f_table.rs
+++ b/src/py/f_table.rs
@@ -5,10 +5,9 @@ use crate::more_ops::{
     op_logior, op_lognot, op_logxor, op_lsh, op_multiply, op_not, op_point_add, op_pubkey_for_exp,
     op_sha256, op_softfork, op_strlen, op_substr, op_subtract,
 };
-use crate::node::Node;
 use crate::reduction::Response;
 
-type OpFn<T> = fn(&Node<T>) -> Response<<T as Allocator>::Ptr>;
+type OpFn<T> = fn(&T, <T as Allocator>::Ptr) -> Response<<T as Allocator>::Ptr>;
 
 pub type FLookup<T> = [Option<OpFn<T>>; 256];
 

--- a/src/py/glue.rs
+++ b/src/py/glue.rs
@@ -50,7 +50,7 @@ where
 #[allow(clippy::too_many_arguments)]
 pub fn _py_run_program<'p, 'a, 'n, A, N>(
     py: Python<'p>,
-    allocator: &'a A,
+    allocator: &'a mut A,
     program: &'n N,
     args: &'n N,
     quote_kw: u8,
@@ -123,11 +123,12 @@ fn raise_eval_error(py: Python, msg: &PyString, sexp: PyObject) -> PyResult<PyOb
     }
 }
 
-pub fn _serialize_from_bytes<A: Allocator, N: PyClass>(allocator: &A, blob: &[u8]) -> N
+pub fn _serialize_from_bytes<A: Allocator, N: PyClass>(allocator: &mut A, blob: &[u8]) -> N
 where
     A: ToPyNode<N>,
 {
-    allocator.to_pynode(&node_from_bytes(allocator, blob).unwrap())
+    let n = node_from_bytes(allocator, blob).unwrap();
+    allocator.to_pynode(&n)
 }
 
 pub fn _serialize_to_bytes<A: Allocator, N>(

--- a/src/py/native_op_lookup.rs
+++ b/src/py/native_op_lookup.rs
@@ -61,7 +61,7 @@ where
 {
     fn op(
         &self,
-        allocator: &A,
+        allocator: &mut A,
         op: A::AtomBuf,
         argument_list: &<A as Allocator>::Ptr,
     ) -> Response<<A as Allocator>::Ptr> {
@@ -78,7 +78,7 @@ where
 fn eval_op<A, N>(
     f_lookup: &FLookup<A>,
     py_callback: &PyObject,
-    allocator: &A,
+    allocator: &mut A,
     o: <A as Allocator>::AtomBuf,
     argument_list: &<A as Allocator>::Ptr,
 ) -> Response<<A as Allocator>::Ptr>
@@ -91,7 +91,7 @@ where
     let op = allocator.buf(&o);
     if op.len() == 1 {
         if let Some(f) = f_lookup[op[0] as usize] {
-            return f(&allocator, argument_list.clone());
+            return f(allocator, argument_list.clone());
         }
     }
 

--- a/src/py/native_op_lookup.rs
+++ b/src/py/native_op_lookup.rs
@@ -5,7 +5,6 @@ use pyo3::types::{PyString, PyTuple};
 use pyo3::PyClass;
 
 use crate::allocator::Allocator;
-use crate::node::Node;
 use crate::reduction::{EvalErr, Reduction, Response};
 use crate::run_program::OperatorHandler;
 
@@ -91,8 +90,7 @@ where
 {
     if op.len() == 1 {
         if let Some(f) = f_lookup[op[0] as usize] {
-            let node_t: Node<A> = Node::new(allocator, argument_list.clone());
-            return f(&node_t);
+            return f(&allocator, argument_list.clone());
         }
     }
 

--- a/src/py/native_op_lookup.rs
+++ b/src/py/native_op_lookup.rs
@@ -62,7 +62,7 @@ where
     fn op(
         &self,
         allocator: &A,
-        op: &[u8],
+        op: A::AtomBuf,
         argument_list: &<A as Allocator>::Ptr,
     ) -> Response<<A as Allocator>::Ptr> {
         eval_op::<A, N>(
@@ -79,7 +79,7 @@ fn eval_op<A, N>(
     f_lookup: &FLookup<A>,
     py_callback: &PyObject,
     allocator: &A,
-    op: &[u8],
+    o: <A as Allocator>::AtomBuf,
     argument_list: &<A as Allocator>::Ptr,
 ) -> Response<<A as Allocator>::Ptr>
 where
@@ -88,6 +88,7 @@ where
     N: PyClass + Clone,
     N: IntoPy<PyObject>,
 {
+    let op = allocator.buf(&o);
     if op.len() == 1 {
         if let Some(f) = f_lookup[op[0] as usize] {
             return f(&allocator, argument_list.clone());

--- a/src/py/py_node.rs
+++ b/src/py/py_node.rs
@@ -122,12 +122,13 @@ impl PyNode {
 
     #[getter(atom)]
     pub fn atom(&self, py: Python) -> Option<PyObject> {
-        match ArcAllocator::new().sexp(&self.node) {
-            SExp::Atom(a) => {
+        let alloc = ArcAllocator::new();
+        match alloc.sexp(&self.node) {
+            SExp::Atom(atom) => {
                 {
                     let mut borrowed_bytes = self.pyobj.borrow_mut();
                     if borrowed_bytes.is_none() {
-                        let b: &PyBytes = PyBytes::new(py, a);
+                        let b: &PyBytes = PyBytes::new(py, alloc.buf(&atom));
                         let obj: PyObject = b.into();
                         *borrowed_bytes = Some(obj);
                     };

--- a/src/py/py_node.rs
+++ b/src/py/py_node.rs
@@ -30,7 +30,7 @@ fn extract_node<'a>(_allocator: &ArcAllocator, obj: &'a PyAny) -> PyResult<PyRef
     Ok(node)
 }
 
-fn extract_tuple(allocator: &ArcAllocator, obj: &PyAny) -> PyResult<PyNode> {
+fn extract_tuple(allocator: &mut ArcAllocator, obj: &PyAny) -> PyResult<PyNode> {
     let v: &PyTuple = obj.downcast()?;
     if v.len() != 2 {
         return Err(PyValueError::new_err("SExp tuples must be size 2"));
@@ -81,13 +81,13 @@ impl ToPyObject for ArcSExp {
 impl PyNode {
     #[new]
     pub fn py_new(obj: &PyAny) -> PyResult<Self> {
-        let allocator = ArcAllocator::new();
+        let mut allocator = ArcAllocator::new();
         let node: PyNode = {
             let n = extract_atom(&allocator, obj);
             if let Ok(r) = n {
                 r
             } else {
-                extract_tuple(&allocator, obj)?
+                extract_tuple(&mut allocator, obj)?
             }
         };
         Ok(node)

--- a/src/py/run_program.rs
+++ b/src/py/run_program.rs
@@ -29,15 +29,14 @@ impl OperatorHandler<IntAllocator> for OperatorHandlerWithMode {
     ) -> Result<Reduction<u32>, EvalErr<u32>> {
         if op.len() == 1 {
             if let Some(f) = F_TABLE[op[0] as usize] {
-                let node_t: Node<IntAllocator> = Node::new(allocator, *argument_list);
-                return f(&node_t);
+                return f(&allocator, *argument_list);
             }
         }
         if self.strict {
             let op_arg = Node::new(allocator, allocator.new_atom(op));
             op_arg.err("unimplemented operator")
         } else {
-            op_unknown(op, &Node::new(allocator, *argument_list))
+            op_unknown(op, allocator, *argument_list)
         }
     }
 }

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -14,7 +14,7 @@ pub trait OperatorHandler<T: Allocator> {
     fn op(
         &self,
         allocator: &T,
-        op: &[u8],
+        op: <T as Allocator>::AtomBuf,
         args: &<T as Allocator>::Ptr,
     ) -> Response<<T as Allocator>::Ptr>;
 }
@@ -304,7 +304,7 @@ where
         } else {
             let r = self
                 .operator_lookup
-                .op(self.allocator, op_atom, &operand_list)?;
+                .op(self.allocator, opa, &operand_list)?;
             self.push(r.1);
             Ok(r.0)
         }

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -216,7 +216,8 @@ where
         match self.allocator.sexp(program) {
             // the program is just a bitfield path through the args tree
             SExp::Atom(path) => {
-                let r: Reduction<T::Ptr> = traverse_path(self.allocator, path, &args)?;
+                let r: Reduction<T::Ptr> =
+                    traverse_path(self.allocator, self.allocator.buf(&path), &args)?;
                 self.push(r.1);
                 Ok(r.0)
             }
@@ -229,9 +230,12 @@ where
                     self.op_stack.push(Box::new(|r| r.eval_op()));
                     Ok(1)
                 }
-                SExp::Atom(op_atom) => {
-                    self.eval_op_atom(&op_atom, &operator_node, &operand_list, args)
-                }
+                SExp::Atom(op_atom) => self.eval_op_atom(
+                    &self.allocator.buf(&op_atom),
+                    &operator_node,
+                    &operand_list,
+                    args,
+                ),
             },
         }
     }
@@ -269,7 +273,8 @@ where
         let operator = self.pop()?;
         match self.allocator.sexp(&operator) {
             SExp::Pair(_, _) => Err(EvalErr(operator, "internal error".into())),
-            SExp::Atom(op_atom) => {
+            SExp::Atom(opa) => {
+                let op_atom = self.allocator.buf(&opa);
                 if op_atom.len() == 1 && op_atom[0] == self.apply_kw {
                     let operand_list = Node::new(self.allocator, operand_list);
                     if operand_list.arg_count_is(2) {

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -118,7 +118,10 @@ enum ParseOp {
     Cons,
 }
 
-pub fn node_from_stream<T: Allocator>(allocator: &T, f: &mut dyn Read) -> std::io::Result<T::Ptr> {
+pub fn node_from_stream<T: Allocator>(
+    allocator: &mut T,
+    f: &mut dyn Read,
+) -> std::io::Result<T::Ptr> {
     let mut values: Vec<T::Ptr> = Vec::new();
     let mut ops = vec![ParseOp::SExp];
 
@@ -159,7 +162,7 @@ pub fn node_from_stream<T: Allocator>(allocator: &T, f: &mut dyn Read) -> std::i
     Ok(values.pop().unwrap())
 }
 
-pub fn node_from_bytes<T: Allocator>(allocator: &T, b: &[u8]) -> std::io::Result<T::Ptr> {
+pub fn node_from_bytes<T: Allocator>(allocator: &mut T, b: &[u8]) -> std::io::Result<T::Ptr> {
     let mut buffer = Cursor::new(b);
     node_from_stream(allocator, &mut buffer)
 }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -52,7 +52,8 @@ pub fn node_to_stream<T: Allocator>(node: &Node<T>, f: &mut dyn Write) -> std::i
         let v = values.pop().unwrap();
         let n = a.sexp(&v);
         match n {
-            SExp::Atom(atom) => {
+            SExp::Atom(atom_ptr) => {
+                let atom = a.buf(&atom_ptr);
                 let size = atom.len();
                 if size == 0 {
                     f.write_all(&[0x80_u8])?;


### PR DESCRIPTION
This patch set adds support for allocators where allocating functions mutate the allocator. Specifically, this means no overlapping allocator references.