### PR TITLE
separate the node list into two separate vectors

### DIFF
--- a/src/int_allocator.rs
+++ b/src/int_allocator.rs
@@ -6,9 +6,10 @@ pub struct IntAtomBuf {
     end: u32,
 }
 
-enum NodePtr {
-    Atom(IntAtomBuf),
-    Pair(u32, u32),
+#[derive(Clone, Copy)]
+pub struct IntPair {
+    first: i32,
+    rest: i32,
 }
 
 pub struct IntAllocator {
@@ -16,7 +17,14 @@ pub struct IntAllocator {
     // are immutable, so once they are created, they will stay around until the
     // program completes
     u8_vec: Vec<u8>,
-    node_vec: Vec<NodePtr>,
+
+    // storage for all pairs (positive indices)
+    pair_vec: Vec<IntPair>,
+
+    // storage for all atoms (negative indices).
+    // node index -1 refers to index 0 in this vector, -2 refers to 1 and so
+    // on.
+    atom_vec: Vec<IntAtomBuf>,
 }
 
 impl Default for IntAllocator {
@@ -29,44 +37,45 @@ impl IntAllocator {
     pub fn new() -> Self {
         let mut r = IntAllocator {
             u8_vec: Vec::new(),
-            node_vec: Vec::new(),
+            pair_vec: Vec::new(),
+            atom_vec: Vec::new(),
         };
         r.u8_vec.reserve(1024 * 1024);
+        r.atom_vec.reserve(256);
+        r.pair_vec.reserve(256);
         r.u8_vec.push(1_u8);
         // Preallocated empty list
-        r.node_vec
-            .push(NodePtr::Atom(IntAtomBuf { start: 0, end: 0 }));
+        r.atom_vec.push(IntAtomBuf { start: 0, end: 0 });
         // Preallocated 1
-        r.node_vec
-            .push(NodePtr::Atom(IntAtomBuf { start: 0, end: 1 }));
+        r.atom_vec.push(IntAtomBuf { start: 0, end: 1 });
         r
     }
 }
 
 impl Allocator for IntAllocator {
-    type Ptr = u32;
+    type Ptr = i32;
     type AtomBuf = IntAtomBuf;
 
     fn new_atom(&mut self, v: &[u8]) -> Self::Ptr {
         let start = self.u8_vec.len() as u32;
         self.u8_vec.extend_from_slice(v);
         let end = self.u8_vec.len() as u32;
-        let r = self.node_vec.len() as u32;
-        self.node_vec.push(NodePtr::Atom(IntAtomBuf { start, end }));
-        r
+        self.atom_vec.push(IntAtomBuf { start, end });
+        -(self.atom_vec.len() as i32)
     }
 
     fn new_pair(&mut self, first: Self::Ptr, rest: Self::Ptr) -> Self::Ptr {
-        let r: u32 = self.node_vec.len() as u32;
-        self.node_vec.push(NodePtr::Pair(first, rest));
+        let r = self.pair_vec.len() as i32;
+        self.pair_vec.push(IntPair { first, rest });
         r
     }
 
     fn atom<'a>(&'a self, node: &'a Self::Ptr) -> &'a [u8] {
-        match self.node_vec[*node as usize] {
-            NodePtr::Atom(IntAtomBuf { start, end }) => &self.u8_vec[start as usize..end as usize],
-            _ => panic!("expected atom, got pair"),
+        if *node >= 0 {
+            panic!("expected atom, got pair");
         }
+        let atom = self.atom_vec[(-*node - 1) as usize];
+        &self.u8_vec[atom.start as usize..atom.end as usize]
     }
 
     fn buf<'a>(&'a self, node: &'a Self::AtomBuf) -> &'a [u8] {
@@ -74,17 +83,20 @@ impl Allocator for IntAllocator {
     }
 
     fn sexp(&self, node: &Self::Ptr) -> SExp<Self::Ptr, Self::AtomBuf> {
-        match self.node_vec[*node as usize] {
-            NodePtr::Atom(atombuf) => SExp::Atom(atombuf),
-            NodePtr::Pair(left, right) => SExp::Pair(left, right),
+        if *node >= 0 {
+            let pair = self.pair_vec[*node as usize];
+            SExp::Pair(pair.first, pair.rest)
+        } else {
+            let atom = self.atom_vec[(-*node - 1) as usize];
+            SExp::Atom(atom)
         }
     }
 
     fn null(&self) -> Self::Ptr {
-        0
+        -1
     }
 
     fn one(&self) -> Self::Ptr {
-        1
+        -2
     }
 }


### PR DESCRIPTION
to avoid the overhead of a variant discriminator for every item. This should decrease memory pressure.

It shows a small performance improvement in the benchmarks (about 3.5 %)

```
$ python benchmark/cmp.py before.txt after.txt
        1509a62d.hex mean: 0.022263 (-0.002348) -9.54 % (within uncertainty)
        73d19fac.hex mean: 0.046827 (-0.006502) -12.19 % (within uncertainty)
        ca4b27bc.hex mean: 0.023823 (-0.002127) -8.20 % (within uncertainty)
          concat.hex mean: 0.634571 (-0.035736) -5.33 % (within uncertainty)
      count-even.hex mean: 0.032501 (-0.003437) -9.56 % (within uncertainty)
        d20e7d20.hex mean: 0.019012 (-0.002185) -10.31 % (within uncertainty)
       factorial.hex mean: 0.178255 (-0.004526) -2.48 % (within uncertainty)
     hash-string.hex mean: 0.337750 (-0.003297) -0.97 % (within uncertainty)
       hash-tree.hex mean: 0.070640 (-0.007488) -9.58 % (within uncertainty)
     large-block.hex mean: 0.427025 (-0.032651) -7.10 % (within uncertainty)
 matrix-multiply.hex mean: 0.377796 (-0.034381) -8.34 %
       point-pow.hex mean: 1.259553 (-0.006682) -0.53 % (within uncertainty)
     pubkey-tree.hex mean: 0.463226 (-0.005521) -1.18 % (within uncertainty)
      shift-left.hex mean: 2.317158 (-0.046278) -1.96 % (within uncertainty)
     substr-tree.hex mean: 0.385590 (-0.025769) -6.26 % (within uncertainty)
          substr.hex mean: 0.116922 (-0.005582) -4.56 % (within uncertainty)
        sum-tree.hex mean: 0.594497 (-0.041585) -6.54 % (within uncertainty)
TOTAL: 365.370418 (-13.304822) -3.51 %
```