### PR TITLE
zero-copy substr

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -16,6 +16,9 @@ pub trait Allocator {
     fn new_atom(&mut self, v: &[u8]) -> Self::Ptr;
     fn new_pair(&mut self, first: Self::Ptr, rest: Self::Ptr) -> Self::Ptr;
 
+    // create a new atom whose value is the given slice of the specified atom
+    fn new_substr(&mut self, node: Self::Ptr, start: u32, end: u32) -> Self::Ptr;
+
     // The lifetime here is a bit special because IntAllocator and ArcAllocator
     // have slightly different requirements. With IntAllocator, all buffers are
     // owned by the allocator, with ArcAllocator all buffers have shared

--- a/src/int_allocator.rs
+++ b/src/int_allocator.rs
@@ -70,6 +70,28 @@ impl Allocator for IntAllocator {
         r
     }
 
+    fn new_substr(&mut self, node: Self::Ptr, start: u32, end: u32) -> Self::Ptr {
+        if node >= 0 {
+            panic!("substr expected atom, got pair");
+        }
+        let atom = self.atom_vec[(-node - 1) as usize];
+        let atom_len = atom.end - atom.start;
+        if start > atom_len {
+            panic!("substr start out of bounds");
+        }
+        if end > atom_len {
+            panic!("substr end out of bounds");
+        }
+        if end < start {
+            panic!("substr invalid bounds");
+        }
+        self.atom_vec.push(IntAtomBuf {
+            start: atom.start + start,
+            end: atom.start + end,
+        });
+        -(self.atom_vec.len() as i32)
+    }
+
     fn atom<'a>(&'a self, node: &'a Self::Ptr) -> &'a [u8] {
         if *node >= 0 {
             panic!("expected atom, got pair");


### PR DESCRIPTION
This PR sits on top of https://github.com/Chia-Network/clvm_rs/pull/31, which should land first.

This patch implements zer-copy substring, by extending the allocator with a new function to create an atom based on a part of an existing atom. Since all atoms are immutable, the new atom can simply point into the firsts memory.

There are two benchmarks that exercise `substr`, it's really only one of them that has a measurable improvement (but it's quite substantial):

```
    substr-tree.hex mean: 0.378359 (-0.008424) -2.18 % (within uncertainty)
          substr.hex mean: 0.018781 (-0.092265) -83.09 %
```

All other benchmarks are unaffected (within the random variability).