### PR TITLE
Renumber opcodes

### DIFF
--- a/src/py/api.rs
+++ b/src/py/api.rs
@@ -9,7 +9,10 @@ use super::arc_allocator::ArcAllocator;
 use super::glue::{_py_run_program, _serialize_from_bytes, _serialize_to_bytes};
 use super::native_op_lookup::GenericNativeOpLookup;
 use super::py_node::PyNode;
-use super::run_program::{__pyo3_get_function_serialize_and_run_program, STRICT_MODE};
+use super::run_program::{
+    __pyo3_get_function_deserialize_and_run_program, __pyo3_get_function_serialize_and_run_program,
+    STRICT_MODE,
+};
 
 type AllocatorT<'a> = ArcAllocator;
 type NodeClass = PyNode;
@@ -22,7 +25,7 @@ pub struct NativeOpLookup {
 #[pymethods]
 impl NativeOpLookup {
     #[new]
-    fn new(opcode_lookup_by_name: HashMap<String, &[u8]>, unknown_op_callback: PyObject) -> Self {
+    fn new(opcode_lookup_by_name: HashMap<String, Vec<u8>>, unknown_op_callback: PyObject) -> Self {
         NativeOpLookup::new_from_gnol(Box::new(GenericNativeOpLookup::new(
             opcode_lookup_by_name,
             unknown_op_callback,
@@ -117,10 +120,11 @@ fn serialize_to_bytes(py: Python, sexp: &PyAny) -> PyResult<PyObject> {
 #[pymodule]
 fn clvm_rs(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_run_program, m)?)?;
-    m.add_function(wrap_pyfunction!(serialize_and_run_program, m)?)?;
     m.add_function(wrap_pyfunction!(serialize_from_bytes, m)?)?;
     m.add_function(wrap_pyfunction!(serialize_to_bytes, m)?)?;
 
+    m.add_function(wrap_pyfunction!(serialize_and_run_program, m)?)?;
+    m.add_function(wrap_pyfunction!(deserialize_and_run_program, m)?)?;
     m.add("STRICT_MODE", STRICT_MODE)?;
 
     m.add_class::<PyNode>()?;

--- a/src/py/api.rs
+++ b/src/py/api.rs
@@ -1,10 +1,11 @@
+use std::collections::HashMap;
+
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyString};
 use pyo3::wrap_pyfunction;
 use pyo3::PyObject;
 
 use super::arc_allocator::ArcAllocator;
-use super::f_table::make_f_lookup;
 use super::glue::{_py_run_program, _serialize_from_bytes, _serialize_to_bytes};
 use super::native_op_lookup::GenericNativeOpLookup;
 use super::py_node::PyNode;
@@ -21,16 +22,10 @@ pub struct NativeOpLookup {
 #[pymethods]
 impl NativeOpLookup {
     #[new]
-    fn new(native_opcode_list: &[u8], unknown_op_callback: PyObject) -> Self {
-        let native_lookup = make_f_lookup::<AllocatorT>();
-        let mut f_lookup = [None; 256];
-        for i in native_opcode_list.iter() {
-            let idx = *i as usize;
-            f_lookup[idx] = native_lookup[idx];
-        }
+    fn new(opcode_lookup_by_name: HashMap<String, &[u8]>, unknown_op_callback: PyObject) -> Self {
         NativeOpLookup::new_from_gnol(Box::new(GenericNativeOpLookup::new(
+            opcode_lookup_by_name,
             unknown_op_callback,
-            f_lookup,
         )))
     }
 }

--- a/src/py/f_table.rs
+++ b/src/py/f_table.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::allocator::Allocator;
 use crate::core_ops::{op_cons, op_eq, op_first, op_if, op_listp, op_raise, op_rest};
 use crate::more_ops::{
@@ -10,47 +12,6 @@ use crate::reduction::Response;
 type OpFn<T> = fn(&mut T, <T as Allocator>::Ptr) -> Response<<T as Allocator>::Ptr>;
 
 pub type FLookup<T> = [Option<OpFn<T>>; 256];
-
-pub fn make_f_lookup<T: Allocator>() -> FLookup<T> {
-    let opcode_lookup: [(u8, OpFn<T>); 30] = [
-        (4, op_if),
-        (5, op_cons),
-        (6, op_first),
-        (7, op_rest),
-        (8, op_listp),
-        (9, op_raise),
-        (10, op_eq),
-        (11, op_sha256),
-        (12, op_add),
-        (13, op_subtract),
-        (14, op_multiply),
-        (15, op_divmod),
-        (16, op_substr),
-        (17, op_strlen),
-        (18, op_point_add),
-        (19, op_pubkey_for_exp),
-        (20, op_concat),
-        (22, op_gr),
-        (23, op_gr_bytes),
-        (24, op_logand),
-        (25, op_logior),
-        (26, op_logxor),
-        (27, op_lognot),
-        (28, op_ash),
-        (29, op_lsh),
-        (30, op_not),
-        (31, op_any),
-        (32, op_all),
-        (33, op_softfork),
-        (34, op_div),
-    ];
-    let mut f_lookup: FLookup<T> = [None; 256];
-    for (op, f) in &opcode_lookup {
-        f_lookup[*op as usize] = Some(*f);
-    }
-
-    f_lookup
-}
 
 pub fn opcode_by_name<T: Allocator>(name: &str) -> Option<OpFn<T>> {
     let opcode_lookup: [(&str, OpFn<T>); 30] = [
@@ -93,4 +54,21 @@ pub fn opcode_by_name<T: Allocator>(name: &str) -> Option<OpFn<T>> {
         }
     }
     None
+}
+
+pub fn f_lookup_for_hashmap<A: Allocator>(
+    opcode_lookup_by_name: HashMap<String, &[u8]>,
+) -> FLookup<A> {
+    let mut f_lookup = [None; 256];
+    for (name, idx) in opcode_lookup_by_name.iter() {
+        if idx.len() == 1 {
+            let index = idx[0];
+            let op = opcode_by_name(name);
+            if op.is_none() {
+                panic!("can't find native operator {:?}", name);
+            }
+            f_lookup[index as usize] = op;
+        }
+    }
+    f_lookup
 }

--- a/src/py/f_table.rs
+++ b/src/py/f_table.rs
@@ -14,40 +14,40 @@ type OpFn<T> = fn(&mut T, <T as Allocator>::Ptr) -> Response<<T as Allocator>::P
 pub type FLookup<T> = [Option<OpFn<T>>; 256];
 
 pub fn opcode_by_name<T: Allocator>(name: &str) -> Option<OpFn<T>> {
-    let opcode_lookup: [(&str, OpFn<T>); 30] = [
-        ("i", op_if),
-        ("c", op_cons),
-        ("f", op_first),
-        ("r", op_rest),
-        ("l", op_listp),
-        ("x", op_raise),
-        ("=", op_eq),
-        ("sha256", op_sha256),
-        ("+", op_add),
-        ("-", op_subtract),
-        ("*", op_multiply),
-        ("divmod", op_divmod),
-        ("substr", op_substr),
-        ("strlen", op_strlen),
-        ("point_add", op_point_add),
-        ("pubkey_for_exp", op_pubkey_for_exp),
-        ("concat", op_concat),
-        (">", op_gr),
-        (">s", op_gr_bytes),
-        ("logand", op_logand),
-        ("logior", op_logior),
-        ("logxor", op_logxor),
-        ("lognot", op_lognot),
-        ("ash", op_ash),
-        ("lsh", op_lsh),
-        ("not", op_not),
-        ("any", op_any),
-        ("all", op_all),
-        ("softfork", op_softfork),
-        ("div", op_div),
+    let opcode_lookup: [(OpFn<T>, &str); 30] = [
+        (op_if, "op_if"),
+        (op_cons, "op_cons"),
+        (op_first, "op_first"),
+        (op_rest, "op_rest"),
+        (op_listp, "op_listp"),
+        (op_raise, "op_raise"),
+        (op_eq, "op_eq"),
+        (op_sha256, "op_sha256"),
+        (op_add, "op_add"),
+        (op_subtract, "op_subtract"),
+        (op_multiply, "op_multiply"),
+        (op_divmod, "op_divmod"),
+        (op_substr, "op_substr"),
+        (op_strlen, "op_strlen"),
+        (op_point_add, "op_point_add"),
+        (op_pubkey_for_exp, "op_pubkey_for_exp"),
+        (op_concat, "op_concat"),
+        (op_gr, "op_gr"),
+        (op_gr_bytes, "op_gr_bytes"),
+        (op_logand, "op_logand"),
+        (op_logior, "op_logior"),
+        (op_logxor, "op_logxor"),
+        (op_lognot, "op_lognot"),
+        (op_ash, "op_ash"),
+        (op_lsh, "op_lsh"),
+        (op_not, "op_not"),
+        (op_any, "op_any"),
+        (op_all, "op_all"),
+        (op_softfork, "op_softfork"),
+        (op_div, "op_div"),
     ];
     let name: &[u8] = name.as_ref();
-    for (op, f) in opcode_lookup.iter() {
+    for (f, op) in opcode_lookup.iter() {
         let pu8: &[u8] = op.as_ref();
         if pu8 == name {
             return Some(*f);
@@ -57,7 +57,7 @@ pub fn opcode_by_name<T: Allocator>(name: &str) -> Option<OpFn<T>> {
 }
 
 pub fn f_lookup_for_hashmap<A: Allocator>(
-    opcode_lookup_by_name: HashMap<String, &[u8]>,
+    opcode_lookup_by_name: HashMap<String, Vec<u8>>,
 ) -> FLookup<A> {
     let mut f_lookup = [None; 256];
     for (name, idx) in opcode_lookup_by_name.iter() {

--- a/src/py/f_table.rs
+++ b/src/py/f_table.rs
@@ -51,3 +51,46 @@ pub fn make_f_lookup<T: Allocator>() -> FLookup<T> {
 
     f_lookup
 }
+
+pub fn opcode_by_name<T: Allocator>(name: &str) -> Option<OpFn<T>> {
+    let opcode_lookup: [(&str, OpFn<T>); 30] = [
+        ("i", op_if),
+        ("c", op_cons),
+        ("f", op_first),
+        ("r", op_rest),
+        ("l", op_listp),
+        ("x", op_raise),
+        ("=", op_eq),
+        ("sha256", op_sha256),
+        ("+", op_add),
+        ("-", op_subtract),
+        ("*", op_multiply),
+        ("divmod", op_divmod),
+        ("substr", op_substr),
+        ("strlen", op_strlen),
+        ("point_add", op_point_add),
+        ("pubkey_for_exp", op_pubkey_for_exp),
+        ("concat", op_concat),
+        (">", op_gr),
+        (">s", op_gr_bytes),
+        ("logand", op_logand),
+        ("logior", op_logior),
+        ("logxor", op_logxor),
+        ("lognot", op_lognot),
+        ("ash", op_ash),
+        ("lsh", op_lsh),
+        ("not", op_not),
+        ("any", op_any),
+        ("all", op_all),
+        ("softfork", op_softfork),
+        ("div", op_div),
+    ];
+    let name: &[u8] = name.as_ref();
+    for (op, f) in opcode_lookup.iter() {
+        let pu8: &[u8] = op.as_ref();
+        if pu8 == name {
+            return Some(*f);
+        }
+    }
+    None
+}

--- a/src/py/native_op_lookup.rs
+++ b/src/py/native_op_lookup.rs
@@ -47,7 +47,7 @@ where
     <A as Allocator>::Ptr: From<N>,
 {
     pub fn new(
-        opcode_lookup_by_name: HashMap<String, &[u8]>,
+        opcode_lookup_by_name: HashMap<String, Vec<u8>>,
         unknown_op_callback: PyObject,
     ) -> Self {
         let f_lookup = f_lookup_for_hashmap(opcode_lookup_by_name);

--- a/src/py/native_op_lookup.rs
+++ b/src/py/native_op_lookup.rs
@@ -9,7 +9,7 @@ use crate::allocator::Allocator;
 use crate::reduction::{EvalErr, Reduction, Response};
 use crate::run_program::OperatorHandler;
 
-use super::f_table::{opcode_by_name, FLookup};
+use super::f_table::{f_lookup_for_hashmap, FLookup};
 
 use super::to_py_node::ToPyNode;
 
@@ -50,17 +50,8 @@ where
         opcode_lookup_by_name: HashMap<String, &[u8]>,
         unknown_op_callback: PyObject,
     ) -> Self {
-        let mut f_lookup = [None; 256];
-        for (name, idx) in opcode_lookup_by_name.iter() {
-            if idx.len() == 1 {
-                let index = idx[0];
-                let op = opcode_by_name(name);
-                if op.is_none() {
-                    panic!("can't find native operator {:?}", name);
-                }
-                f_lookup[index as usize] = op;
-            }
-        }
+        let f_lookup = f_lookup_for_hashmap(opcode_lookup_by_name);
+
         GenericNativeOpLookup {
             py_callback: unknown_op_callback,
             f_lookup,

--- a/src/py/run_program.rs
+++ b/src/py/run_program.rs
@@ -50,7 +50,69 @@ pub fn serialize_and_run_program(
     args: &[u8],
     quote_kw: u8,
     apply_kw: u8,
-    opcode_lookup_by_name: HashMap<String, &[u8]>,
+    max_cost: u32,
+    flags: u32,
+) -> PyResult<(u32, Py<PyBytes>)> {
+    let mut opcode_lookup_by_name = HashMap::<String, Vec<u8>>::new();
+    for (v, s) in [
+        (4, "op_if"),
+        (5, "op_cons"),
+        (6, "op_first"),
+        (7, "op_rest"),
+        (8, "op_listp"),
+        (9, "op_raise"),
+        (10, "op_eq"),
+        (11, "op_sha256"),
+        (12, "op_add"),
+        (13, "op_subtract"),
+        (14, "op_multiply"),
+        (15, "op_divmod"),
+        (16, "op_substr"),
+        (17, "op_strlen"),
+        (18, "op_point_add"),
+        (19, "op_pubkey_for_exp"),
+        (20, "op_concat"),
+        (22, "op_gr"),
+        (23, "op_gr_bytes"),
+        (24, "op_logand"),
+        (25, "op_logior"),
+        (26, "op_logxor"),
+        (27, "op_lognot"),
+        (28, "op_ash"),
+        (29, "op_lsh"),
+        (30, "op_not"),
+        (31, "op_any"),
+        (32, "op_all"),
+        (33, "op_softfork"),
+        (34, "op_div"),
+    ]
+    .iter()
+    {
+        let v: Vec<u8> = vec![*v as u8];
+        opcode_lookup_by_name.insert(s.to_string(), v);
+    }
+
+    deserialize_and_run_program(
+        py,
+        program,
+        args,
+        quote_kw,
+        apply_kw,
+        opcode_lookup_by_name,
+        max_cost,
+        flags,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+#[pyfunction]
+pub fn deserialize_and_run_program(
+    py: Python,
+    program: &[u8],
+    args: &[u8],
+    quote_kw: u8,
+    apply_kw: u8,
+    opcode_lookup_by_name: HashMap<String, Vec<u8>>,
     max_cost: u32,
     flags: u32,
 ) -> PyResult<(u32, Py<PyBytes>)> {


### PR DESCRIPTION
Add `deserialize_and_run_program` which takes a hash table of opcode indices and named operator references.