### PR TITLE
support allocators returning errors

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -3,6 +3,7 @@
  * of type `T`. The objects must live until the allocator disappears.
  *
  */
+use crate::reduction::EvalErr;
 
 pub enum SExp<T, B> {
     Atom(B),
@@ -13,11 +14,20 @@ pub trait Allocator {
     type Ptr: Clone;
     type AtomBuf: Clone;
 
-    fn new_atom(&mut self, v: &[u8]) -> Self::Ptr;
-    fn new_pair(&mut self, first: Self::Ptr, rest: Self::Ptr) -> Self::Ptr;
+    fn new_atom(&mut self, v: &[u8]) -> Result<Self::Ptr, EvalErr<Self::Ptr>>;
+    fn new_pair(
+        &mut self,
+        first: Self::Ptr,
+        rest: Self::Ptr,
+    ) -> Result<Self::Ptr, EvalErr<Self::Ptr>>;
 
     // create a new atom whose value is the given slice of the specified atom
-    fn new_substr(&mut self, node: Self::Ptr, start: u32, end: u32) -> Self::Ptr;
+    fn new_substr(
+        &mut self,
+        node: Self::Ptr,
+        start: u32,
+        end: u32,
+    ) -> Result<Self::Ptr, EvalErr<Self::Ptr>>;
 
     // The lifetime here is a bit special because IntAllocator and ArcAllocator
     // have slightly different requirements. With IntAllocator, all buffers are

--- a/src/core_ops.rs
+++ b/src/core_ops.rs
@@ -29,7 +29,7 @@ pub fn op_cons<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
     let a2 = args.rest()?.first()?;
     let n1 = a1.node;
     let n2 = a2.node;
-    let r = a.new_pair(n1, n2);
+    let r = a.new_pair(n1, n2)?;
     Ok(Reduction(CONS_COST, r))
 }
 

--- a/src/err_utils.rs
+++ b/src/err_utils.rs
@@ -5,6 +5,9 @@ pub fn err<T, P>(node: P, msg: &str) -> Result<T, EvalErr<P>> {
     Err(EvalErr(node, msg.into()))
 }
 
+// TODO: if we pass in A::Ptr instead of A::AtomBuf, we don't have to allocate a
+// new atom, and we could avoid the akward possibility of failing to allocate
+// the error message
 pub fn u8_err<A: Allocator, T>(
     allocator: &mut A,
     o: &A::AtomBuf,
@@ -12,5 +15,5 @@ pub fn u8_err<A: Allocator, T>(
 ) -> Result<T, EvalErr<A::Ptr>> {
     let op = allocator.buf(&o);
     let buf = op.to_vec();
-    err(allocator.new_atom(&buf), msg)
+    err(allocator.new_atom(&buf)?, msg)
 }

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,10 +1,14 @@
 use crate::allocator::Allocator;
 use crate::node::Node;
+use crate::reduction::EvalErr;
 
 use num_bigint::BigInt;
 pub type Number = BigInt;
 
-pub fn ptr_from_number<T: Allocator>(allocator: &mut T, item: &Number) -> T::Ptr {
+pub fn ptr_from_number<T: Allocator>(
+    allocator: &mut T,
+    item: &Number,
+) -> Result<T::Ptr, EvalErr<T::Ptr>> {
     let bytes: Vec<u8> = item.to_signed_bytes_be();
     let mut slice = bytes.as_slice();
 
@@ -43,56 +47,56 @@ fn test_ptr_from_number() {
 
     // 0 is encoded as an empty string
     let num = number_from_u8(&[0]);
-    let ptr = ptr_from_number(&mut a, &num);
+    let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "0");
     assert_eq!(a.atom(&ptr).len(), 0);
 
     let num = number_from_u8(&[1]);
-    let ptr = ptr_from_number(&mut a, &num);
+    let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "1");
     assert_eq!(&[1], &a.atom(&ptr));
 
     // leading zeroes are redundant
     let num = number_from_u8(&[0, 0, 0, 1]);
-    let ptr = ptr_from_number(&mut a, &num);
+    let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "1");
     assert_eq!(&[1], &a.atom(&ptr));
 
     let num = number_from_u8(&[0x00, 0x00, 0x80]);
-    let ptr = ptr_from_number(&mut a, &num);
+    let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "128");
     assert_eq!(&[0x00, 0x80], &a.atom(&ptr));
 
     // A leading zero is necessary to encode a positive number with the
     // penultimate byte's most significant bit set
     let num = number_from_u8(&[0x00, 0xff]);
-    let ptr = ptr_from_number(&mut a, &num);
+    let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "255");
     assert_eq!(&[0x00, 0xff], &a.atom(&ptr));
 
     let num = number_from_u8(&[0x7f, 0xff]);
-    let ptr = ptr_from_number(&mut a, &num);
+    let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "32767");
     assert_eq!(&[0x7f, 0xff], &a.atom(&ptr));
 
     // the first byte is redundant, it's still -1
     let num = number_from_u8(&[0xff, 0xff]);
-    let ptr = ptr_from_number(&mut a, &num);
+    let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "-1");
     assert_eq!(&[0xff], &a.atom(&ptr));
 
     let num = number_from_u8(&[0xff]);
-    let ptr = ptr_from_number(&mut a, &num);
+    let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "-1");
     assert_eq!(&[0xff], &a.atom(&ptr));
 
     let num = number_from_u8(&[0x00, 0x80, 0x00]);
     assert_eq!(format!("{}", num), "32768");
-    let ptr = ptr_from_number(&mut a, &num);
+    let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(&[0x00, 0x80, 0x00], &a.atom(&ptr));
 
     let num = number_from_u8(&[0x00, 0x40, 0x00]);
     assert_eq!(format!("{}", num), "16384");
-    let ptr = ptr_from_number(&mut a, &num);
+    let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(&[0x40, 0x00], &a.atom(&ptr));
 }

--- a/src/py/arc_allocator.rs
+++ b/src/py/arc_allocator.rs
@@ -1,5 +1,6 @@
 use crate::allocator::{Allocator, SExp};
-
+use crate::err_utils::err;
+use crate::reduction::EvalErr;
 use std::sync::Arc;
 
 use lazy_static::*;
@@ -41,7 +42,7 @@ impl ArcAllocator {
         ArcAllocator {}
     }
 
-    pub fn blob(&mut self, v: &str) -> ArcSExp {
+    pub fn blob(&mut self, v: &str) -> Result<ArcSExp, EvalErr<ArcSExp>> {
         let v: Vec<u8> = v.into();
         self.new_atom(&v)
     }
@@ -51,38 +52,49 @@ impl Allocator for ArcAllocator {
     type Ptr = ArcSExp;
     type AtomBuf = ArcAtomBuf;
 
-    fn new_atom(&mut self, v: &[u8]) -> ArcSExp {
-        ArcSExp::Atom(ArcAtomBuf {
+    fn new_atom(&mut self, v: &[u8]) -> Result<Self::Ptr, EvalErr<Self::Ptr>> {
+        Ok(ArcSExp::Atom(ArcAtomBuf {
             buf: Arc::new(v.into()),
             start: 0,
             end: v.len() as u32,
-        })
+        }))
     }
 
-    fn new_pair(&mut self, first: ArcSExp, rest: ArcSExp) -> ArcSExp {
-        ArcSExp::Pair(Arc::new(first), Arc::new(rest))
+    fn new_pair(
+        &mut self,
+        first: Self::Ptr,
+        rest: Self::Ptr,
+    ) -> Result<Self::Ptr, EvalErr<Self::Ptr>> {
+        Ok(ArcSExp::Pair(Arc::new(first), Arc::new(rest)))
     }
 
-    fn new_substr(&mut self, node: Self::Ptr, start: u32, end: u32) -> Self::Ptr {
-        let atom = match node {
+    fn new_substr(
+        &mut self,
+        node: Self::Ptr,
+        start: u32,
+        end: u32,
+    ) -> Result<Self::Ptr, EvalErr<Self::Ptr>> {
+        let atom = match &node {
             ArcSExp::Atom(a) => a,
-            _ => panic!("substr expected atom, got pair"),
+            _ => {
+                return err(node, "substr expected atom, got pair");
+            }
         };
         let atom_len = atom.end - atom.start;
         if start > atom_len {
-            panic!("substr start out of bounds");
+            return err(node, "substr start out of bounds");
         }
         if end > atom_len {
-            panic!("substr end out of bounds");
+            return err(node, "substr end out of bounds");
         }
         if end < start {
-            panic!("substr invalid bounds");
+            return err(node, "substr invalid bounds");
         }
-        ArcSExp::Atom(ArcAtomBuf {
+        Ok(ArcSExp::Atom(ArcAtomBuf {
             buf: atom.buf.clone(),
             start: atom.start,
             end: atom.end,
-        })
+        }))
     }
 
     fn atom<'a>(&'a self, node: &'a Self::Ptr) -> &'a [u8] {

--- a/src/py/run_program.rs
+++ b/src/py/run_program.rs
@@ -35,7 +35,7 @@ impl<A: Allocator> OperatorHandler<A> for OperatorHandlerWithMode<A> {
         }
         if self.strict {
             let buf = op.to_vec();
-            let op_arg = allocator.new_atom(&buf);
+            let op_arg = allocator.new_atom(&buf)?;
             err(op_arg, "unimplemented operator")
         } else {
             op_unknown(allocator, o, argument_list.clone())

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -165,7 +165,7 @@ impl<'a, 'h, T: Allocator> RunProgramContext<'a, T> {
         /* Join the top two operands. */
         let v1 = self.pop()?;
         let v2 = self.pop()?;
-        let p = self.allocator.new_pair(v1, v2);
+        let p = self.allocator.new_pair(v1, v2)?;
         self.push(p);
         Ok(0)
     }
@@ -201,7 +201,7 @@ where
                 match self.allocator.sexp(&operands) {
                     SExp::Atom(_) => return err(operand_list.clone(), "bad operand list"),
                     SExp::Pair(first, rest) => {
-                        let new_pair = self.allocator.new_pair(first, args.clone());
+                        let new_pair = self.allocator.new_pair(first, args.clone())?;
                         self.push(new_pair);
                         operands = rest.clone();
                     }
@@ -229,7 +229,7 @@ where
         let op_atom = match self.allocator.sexp(&op_node) {
             SExp::Pair(_, _) => {
                 // the operator is also a list, so we need two evals here
-                let p = self.allocator.new_pair(op_node, args.clone());
+                let p = self.allocator.new_pair(op_node, args.clone())?;
                 self.push(p);
                 self.op_stack.push(Operation::Eval);
                 self.op_stack.push(Operation::Eval);
@@ -283,7 +283,7 @@ where
                 let new_op_list = operand_list.rest()?.first()?.node;
                 match new_operator.sexp() {
                     SExp::Pair(_, _) => {
-                        let new_pair = self.allocator.new_pair(new_op_node, new_op_list);
+                        let new_pair = self.allocator.new_pair(new_op_node, new_op_list)?;
                         self.push(new_pair);
                         self.op_stack.push(Operation::Eval);
                     }
@@ -313,7 +313,7 @@ where
         args: &T::Ptr,
         max_cost: u32,
     ) -> Response<T::Ptr> {
-        self.val_stack = vec![self.allocator.new_pair(program.clone(), args.clone())];
+        self.val_stack = vec![self.allocator.new_pair(program.clone(), args.clone())?];
         self.op_stack = vec![Operation::Eval];
 
         let mut cost: u32 = 0;
@@ -338,7 +338,7 @@ where
             };
             if cost > max_cost && max_cost > 0 {
                 let max_cost: Number = max_cost.into();
-                let ptr = ptr_from_number(self.allocator, &max_cost);
+                let ptr = ptr_from_number(self.allocator, &max_cost)?;
                 let n: Node<T> = Node::new(self.allocator, ptr);
                 return n.err("cost exceeded");
             }
@@ -400,8 +400,8 @@ fn test_traverse_path() {
 
     let mut a = IntAllocator::new();
     let nul = a.null();
-    let n1 = a.new_atom(&[0, 1, 2]);
-    let n2 = a.new_atom(&[4, 5, 6]);
+    let n1 = a.new_atom(&[0, 1, 2]).unwrap();
+    let n2 = a.new_atom(&[4, 5, 6]).unwrap();
 
     assert_eq!(traverse_path(&a, &[0], &n1).unwrap(), Reduction(2, nul));
     assert_eq!(traverse_path(&a, &[0b1], &n1).unwrap(), Reduction(1, n1));
@@ -413,14 +413,14 @@ fn test_traverse_path() {
         Reduction(5, nul)
     );
 
-    let n3 = a.new_pair(n1, n2);
+    let n3 = a.new_pair(n1, n2).unwrap();
     assert_eq!(traverse_path(&a, &[0b1], &n3).unwrap(), Reduction(1, n3));
     assert_eq!(traverse_path(&a, &[0b10], &n3).unwrap(), Reduction(2, n1));
     assert_eq!(traverse_path(&a, &[0b11], &n3).unwrap(), Reduction(2, n2));
     assert_eq!(traverse_path(&a, &[0b11], &n3).unwrap(), Reduction(2, n2));
 
-    let list = a.new_pair(n1, nul);
-    let list = a.new_pair(n2, list);
+    let list = a.new_pair(n1, nul).unwrap();
+    let list = a.new_pair(n2, list).unwrap();
 
     assert_eq!(traverse_path(&a, &[0b10], &list).unwrap(), Reduction(2, n2));
     assert_eq!(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -20,29 +20,29 @@ fn test_roundtrip() {
     let n = a.one();
     test_serialize_roundtrip(&mut a, n);
 
-    let n = a.new_atom(&[1_u8, 2_u8, 3_u8]);
+    let n = a.new_atom(&[1_u8, 2_u8, 3_u8]).unwrap();
     test_serialize_roundtrip(&mut a, n);
 
-    let a1 = a.new_atom(&[1_u8, 2_u8, 3_u8]);
-    let a2 = a.new_atom(&[4_u8, 5_u8, 6_u8]);
-    let p = a.new_pair(a1, a2);
+    let a1 = a.new_atom(&[1_u8, 2_u8, 3_u8]).unwrap();
+    let a2 = a.new_atom(&[4_u8, 5_u8, 6_u8]).unwrap();
+    let p = a.new_pair(a1, a2).unwrap();
     test_serialize_roundtrip(&mut a, p);
 
     for idx in 0..=255 {
-        let n = a.new_atom(&[idx]);
+        let n = a.new_atom(&[idx]).unwrap();
         test_serialize_roundtrip(&mut a, n);
     }
 
     // large blob
     let mut buf = Vec::<u8>::new();
     buf.resize(1000000, 0_u8);
-    let n = a.new_atom(&buf);
+    let n = a.new_atom(&buf).unwrap();
     test_serialize_roundtrip(&mut a, n);
 
     // deep tree
     let mut prev = a.null();
     for _ in 0..=4000 {
-        prev = a.new_pair(a.one(), prev);
+        prev = a.new_pair(a.one(), prev).unwrap();
     }
     test_serialize_roundtrip(&mut a, prev);
 
@@ -50,7 +50,7 @@ fn test_roundtrip() {
     let mut prev = a.null();
     for _ in 0..=4000 {
         let n = a.one();
-        prev = a.new_pair(prev, n);
+        prev = a.new_pair(prev, n).unwrap();
     }
     test_serialize_roundtrip(&mut a, prev);
 }
@@ -68,21 +68,21 @@ fn test_serialize_blobs() {
     assert_eq!(node_to_bytes(&n).unwrap(), &[1]);
 
     // single byte
-    let atom = a.new_atom(&[128]);
+    let atom = a.new_atom(&[128]).unwrap();
     let n = Node::new(&a, atom);
     assert_eq!(node_to_bytes(&n).unwrap(), &[0x81, 128]);
     let n = n.node;
     test_serialize_roundtrip(&mut a, n);
 
     // two bytes
-    let atom = a.new_atom(&[0x10, 0xff]);
+    let atom = a.new_atom(&[0x10, 0xff]).unwrap();
     let n = Node::new(&a, atom);
     assert_eq!(node_to_bytes(&n).unwrap(), &[0x82, 0x10, 0xff]);
     let n = n.node;
     test_serialize_roundtrip(&mut a, n);
 
     // three bytes
-    let atom = a.new_atom(&[0xff, 0x10, 0xff]);
+    let atom = a.new_atom(&[0xff, 0x10, 0xff]).unwrap();
     let n = Node::new(&a, atom);
     assert_eq!(node_to_bytes(&n).unwrap(), &[0x83, 0xff, 0x10, 0xff]);
     let n = n.node;
@@ -98,11 +98,11 @@ fn test_serialize_lists() {
     assert_eq!(node_to_bytes(&Node::new(&a, n)).unwrap(), &[0x80]);
 
     // one item
-    let n = a.new_pair(a.one(), n);
+    let n = a.new_pair(a.one(), n).unwrap();
     assert_eq!(node_to_bytes(&Node::new(&a, n)).unwrap(), &[0xff, 1, 0x80]);
 
     // two items
-    let n = a.new_pair(a.one(), n);
+    let n = a.new_pair(a.one(), n).unwrap();
     assert_eq!(
         node_to_bytes(&Node::new(&a, n)).unwrap(),
         &[0xff, 1, 0xff, 1, 0x80]
@@ -110,7 +110,7 @@ fn test_serialize_lists() {
     test_serialize_roundtrip(&mut a, n);
 
     // three items
-    let n = a.new_pair(a.one(), n);
+    let n = a.new_pair(a.one(), n).unwrap();
     assert_eq!(
         node_to_bytes(&Node::new(&a, n)).unwrap(),
         &[0xff, 1, 0xff, 1, 0xff, 1, 0x80]
@@ -119,9 +119,9 @@ fn test_serialize_lists() {
 
     // a backwards list
     let n = a.one();
-    let n = a.new_pair(n, a.one());
-    let n = a.new_pair(n, a.one());
-    let n = a.new_pair(n, a.one());
+    let n = a.new_pair(n, a.one()).unwrap();
+    let n = a.new_pair(n, a.one()).unwrap();
+    let n = a.new_pair(n, a.one()).unwrap();
     assert_eq!(
         node_to_bytes(&Node::new(&a, n)).unwrap(),
         &[0xff, 0xff, 0xff, 1, 1, 1, 1]
@@ -133,13 +133,13 @@ fn test_serialize_lists() {
 fn test_serialize_tree() {
     let mut a = IntAllocator::new();
 
-    let a1 = a.new_atom(&[1]);
-    let a2 = a.new_atom(&[2]);
-    let a3 = a.new_atom(&[3]);
-    let a4 = a.new_atom(&[4]);
-    let l = a.new_pair(a1, a2);
-    let r = a.new_pair(a3, a4);
-    let n = a.new_pair(l, r);
+    let a1 = a.new_atom(&[1]).unwrap();
+    let a2 = a.new_atom(&[2]).unwrap();
+    let a3 = a.new_atom(&[3]).unwrap();
+    let a4 = a.new_atom(&[4]).unwrap();
+    let l = a.new_pair(a1, a2).unwrap();
+    let r = a.new_pair(a3, a4).unwrap();
+    let n = a.new_pair(l, r).unwrap();
     assert_eq!(
         node_to_bytes(&Node::new(&a, n)).unwrap(),
         &[0xff, 0xff, 1, 2, 0xff, 3, 4]


### PR DESCRIPTION
Also turn the out-of-bounds `panic!()`s into proper error responses.