### PR TITLE
Enforce max cost

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -78,3 +78,46 @@ jobs:
         . ./activate
         python benchmark/run-benchmark.py
 
+  max-cost-checks:
+    name: Cost checks
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - uses: actions/setup-python@v2
+      name: Install Python 3.9
+      with:
+        python-version: 3.9
+
+    - name: Update pip
+      run: |
+          python -m pip install --upgrade pip
+
+    - name: Set up rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Install dependencies
+      run: |
+        python -m pip install maturin
+
+    - name: Build
+      run: |
+        python -m venv venv
+        ln -s venv/bin/activate
+        . ./activate
+        git clone https://github.com/Chia-Network/clvm_tools.git --branch=develop --single-branch
+        python -m pip install ./clvm_tools
+        maturin develop --release
+
+    - name: Run cost checks
+      run: |
+        . ./activate
+        cd tests
+        ./generate-programs.py
+        ./run-programs.py
+

--- a/src/core_ops.rs
+++ b/src/core_ops.rs
@@ -12,7 +12,7 @@ const LISTP_COST: Cost = 5;
 const CMP_BASE_COST: Cost = 16;
 const CMP_COST_PER_LIMB_DIVIDER: Cost = 64;
 
-pub fn op_if<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
+pub fn op_if<T: Allocator>(a: &mut T, input: T::Ptr, _max_cost: Cost) -> Response<T::Ptr> {
     let args = Node::new(a, input);
     check_arg_count(&args, 3, "i")?;
     let cond = args.first()?;
@@ -23,7 +23,7 @@ pub fn op_if<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
     Ok(Reduction(IF_COST, chosen_node.first()?.node))
 }
 
-pub fn op_cons<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
+pub fn op_cons<T: Allocator>(a: &mut T, input: T::Ptr, _max_cost: Cost) -> Response<T::Ptr> {
     let args = Node::new(a, input);
     check_arg_count(&args, 2, "c")?;
     let a1 = args.first()?;
@@ -34,19 +34,19 @@ pub fn op_cons<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
     Ok(Reduction(CONS_COST, r))
 }
 
-pub fn op_first<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
+pub fn op_first<T: Allocator>(a: &mut T, input: T::Ptr, _max_cost: Cost) -> Response<T::Ptr> {
     let args = Node::new(a, input);
     check_arg_count(&args, 1, "f")?;
     Ok(Reduction(FIRST_COST, args.first()?.first()?.node))
 }
 
-pub fn op_rest<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
+pub fn op_rest<T: Allocator>(a: &mut T, input: T::Ptr, _max_cost: Cost) -> Response<T::Ptr> {
     let args = Node::new(a, input);
     check_arg_count(&args, 1, "r")?;
     Ok(Reduction(REST_COST, args.first()?.rest()?.node))
 }
 
-pub fn op_listp<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
+pub fn op_listp<T: Allocator>(a: &mut T, input: T::Ptr, _max_cost: Cost) -> Response<T::Ptr> {
     let args = Node::new(a, input);
     check_arg_count(&args, 1, "l")?;
     match args.first()?.pair() {
@@ -55,12 +55,12 @@ pub fn op_listp<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
     }
 }
 
-pub fn op_raise<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
+pub fn op_raise<T: Allocator>(a: &mut T, input: T::Ptr, _max_cost: Cost) -> Response<T::Ptr> {
     let args = Node::new(a, input);
     args.err("clvm raise")
 }
 
-pub fn op_eq<T: Allocator>(a: &mut T, input: T::Ptr) -> Response<T::Ptr> {
+pub fn op_eq<T: Allocator>(a: &mut T, input: T::Ptr, _max_cost: Cost) -> Response<T::Ptr> {
     let args = Node::new(a, input);
     check_arg_count(&args, 2, "=")?;
     let a0 = args.first()?;

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -1,1 +1,12 @@
+use crate::allocator::Allocator;
+use crate::reduction::EvalErr;
+
 pub type Cost = u64;
+
+pub fn check_cost<A: Allocator>(a: &A, cost: Cost, max_cost: Cost) -> Result<(), EvalErr<A::Ptr>> {
+    if cost > max_cost {
+        Err(EvalErr(a.null(), "cost exceeded".into()))
+    } else {
+        Ok(())
+    }
+}

--- a/src/py/f_table.rs
+++ b/src/py/f_table.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use crate::allocator::Allocator;
 use crate::core_ops::{op_cons, op_eq, op_first, op_if, op_listp, op_raise, op_rest};
+use crate::cost::Cost;
 use crate::more_ops::{
     op_add, op_all, op_any, op_ash, op_concat, op_div, op_divmod, op_gr, op_gr_bytes, op_logand,
     op_logior, op_lognot, op_logxor, op_lsh, op_multiply, op_not, op_point_add, op_pubkey_for_exp,
@@ -9,7 +10,7 @@ use crate::more_ops::{
 };
 use crate::reduction::Response;
 
-type OpFn<T> = fn(&mut T, <T as Allocator>::Ptr) -> Response<<T as Allocator>::Ptr>;
+type OpFn<T> = fn(&mut T, <T as Allocator>::Ptr, Cost) -> Response<<T as Allocator>::Ptr>;
 
 pub type FLookup<T> = [Option<OpFn<T>>; 256];
 

--- a/src/py/native_op_lookup.rs
+++ b/src/py/native_op_lookup.rs
@@ -72,6 +72,7 @@ where
         allocator: &mut A,
         op: A::AtomBuf,
         argument_list: &<A as Allocator>::Ptr,
+        max_cost: Cost,
     ) -> Response<<A as Allocator>::Ptr> {
         eval_op::<A, N>(
             &self.f_lookup,
@@ -79,6 +80,7 @@ where
             allocator,
             op,
             argument_list,
+            max_cost,
         )
     }
 }
@@ -89,6 +91,7 @@ fn eval_op<A, N>(
     allocator: &mut A,
     o: <A as Allocator>::AtomBuf,
     argument_list: &<A as Allocator>::Ptr,
+    max_cost: Cost,
 ) -> Response<<A as Allocator>::Ptr>
 where
     A: Allocator + ToPyNode<N>,
@@ -99,7 +102,7 @@ where
     let op = allocator.buf(&o);
     if op.len() == 1 {
         if let Some(f) = f_lookup[op[0] as usize] {
-            return f(allocator, argument_list.clone());
+            return f(allocator, argument_list.clone(), max_cost);
         }
     }
 

--- a/src/py/run_program.rs
+++ b/src/py/run_program.rs
@@ -27,11 +27,12 @@ impl<A: Allocator> OperatorHandler<A> for OperatorHandlerWithMode<A> {
         allocator: &mut A,
         o: <A as Allocator>::AtomBuf,
         argument_list: &A::Ptr,
+        max_cost: Cost,
     ) -> Response<<A as Allocator>::Ptr> {
         let op = &allocator.buf(&o);
         if op.len() == 1 {
             if let Some(f) = self.f_lookup[op[0] as usize] {
-                return f(allocator, argument_list.clone());
+                return f(allocator, argument_list.clone(), max_cost);
             }
         }
         if self.strict {
@@ -39,7 +40,7 @@ impl<A: Allocator> OperatorHandler<A> for OperatorHandlerWithMode<A> {
             let op_arg = allocator.new_atom(&buf)?;
             err(op_arg, "unimplemented operator")
         } else {
-            op_unknown(allocator, o, argument_list.clone())
+            op_unknown(allocator, o, argument_list.clone(), max_cost)
         }
     }
 }

--- a/tests/generate-programs.py
+++ b/tests/generate-programs.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+import os
+
+def many_args(filename, op, num):
+    with open(filename, 'w+') as f:
+        f.write('''
+;(mod (n)
+;    (defun large-atom (n)
+;        (if n (lsh (large-atom (- n 1)) 65535) 0x80)
+;    )
+;    (defun raise (atom)
+;        (%s atom ... )
+;    )
+;    (raise (large-atom n))
+;)
+''' % op)
+
+        f.write('((c (q (c 6 (c 2 (c ((c 4 (c 2 (c 5 (q))))) (q))))) (c (q ((c (i 5 (q 23 ((c 4 (c 2 (c (- 5 (q . 1)) (q))))) (q . 0x00ffff)) (q 1 . -128)) 1)) %s' % op)
+        f.write(' 5' * num)
+        f.write(') 1)))')
+
+    with open(filename[:-4] + 'env', 'w+') as f:
+        f.write('(200)')
+
+def many_args_point(filename, op, num):
+    with open(filename, 'w+') as f:
+        f.write(''';(mod (n)
+;    (defun raise (atom)
+;        (%s atom atom atom atom atom atom atom atom atom atom atom atom atom atom)
+;    )
+;    (raise (logxor n 0xb3b8ac537f4fd6bde9b26221d49b54b17a506be147347dae5d081c0a6572b611d8484e338f3432971a9823976c6a232b))
+;)
+''' % op)
+        f.write('((c (q (c 2 (c 2 (c (logxor (q . 0xb3b8ac537f4fd6bde9b26221d49b54b17a506be147347dae5d081c0a6572b611d8484e338f3432971a9823976c6a232b)) (q))))) (c (q %s' % op)
+        f.write(' 5' * num)
+        f.write(') 1)))')
+
+    with open(filename[:-4] + 'env', 'w+') as f:
+        f.write('(0)')
+
+def softfork_wrap(filename, val):
+
+    with open(filename, 'w+') as f:
+        f.write(''';(mod (n)
+;    (defun recurse (count)
+;        (if (= 0 count) 42 (recurse (+ (- count 1) (softfork %s))))
+;    )
+;    (recurse n)
+;)
+
+((c (q (c 2 (c 2 (c 5 (q))))) (c (q (c (i (= (q) 5) (q 1 . 42) (q (c 2 (c 2 (c (+ (- 5 (q . 1)) (softfork (q . %s))) (q)))))) 1)) 1)))
+''' % (val, val))
+
+    with open(filename[:-4] + 'env', 'w+') as f:
+        f.write('(0xffffffff)')
+
+try:
+    os.mkdir('programs')
+except:
+    pass
+
+many_args('programs/args-mul.clvm', '*', 300)
+many_args('programs/args-add.clvm', '+', 6000)
+many_args('programs/args-sub.clvm', '-', 6000)
+many_args('programs/args-sha.clvm', 'sha256', 300)
+many_args('programs/args-cat.clvm', 'concat', 1200)
+many_args('programs/args-any.clvm', 'any', 12000)
+many_args('programs/args-all.clvm', 'all', 12000)
+many_args('programs/args-and.clvm', 'logand', 6000)
+many_args('programs/args-or.clvm', 'logior', 6000)
+many_args('programs/args-xor.clvm', 'logxor', 6000)
+many_args_point('programs/args-point_add.clvm', 'point_add', 12000)
+many_args('programs/args-unknown-1.clvm', '0x7fffffff00', 300)
+many_args('programs/args-unknown-2.clvm', '0x7fff40', 300)
+many_args('programs/args-unknown-3.clvm', '0x7fff80', 300)
+many_args('programs/args-unknown-4.clvm', '0x7fffc0', 300)
+
+# this program attempts to wrap around a 64 bit cost counter
+softfork_wrap('programs/softfork-1.clvm', '0x00ffffffffffffff45')
+# this program attempts to wrap around a 32 bit cost counter
+softfork_wrap('programs/softfork-2.clvm', '0x00ffffff45')
+

--- a/tests/run-programs.py
+++ b/tests/run-programs.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import subprocess
+import glob
+import time
+import sys
+
+ret = 0
+
+for fn in glob.glob('programs/*.clvm'):
+
+    hexname = fn[:-4] + 'hex'
+    with open(hexname, 'w+') as out:
+        proc = subprocess.Popen(['opc', fn], stdout=out)
+        proc.wait()
+
+    env = fn[:-4] + 'env'
+    hexenv = fn[:-4] + 'envhex'
+    with open(hexenv, 'w+') as out:
+        proc = subprocess.Popen(['opc', env], stdout=out)
+        proc.wait()
+
+    command = ['brun', '-m', '10000', '-c', '--backend=rust', '--quiet', '--time', '--hex', hexname, hexenv]
+    print(' '.join(command))
+    start = time.perf_counter()
+    subprocess.run(command)
+    end = time.perf_counter()
+    if end - start > 1:
+        ret = 1
+        print('Time exceeded: %f' % (end - start))
+
+sys.exit(ret)


### PR DESCRIPTION
this patch adds a test that generates clvm programs pushing the limits on single operations that are expensive. It demonstrates the need for all operators that take an unbounded number of arguments to be able to fail early, when max cost is exceeded.

It fixes this problem by passing along the remaining cost into all operator functions.