### PR TITLE
Fix parser

### DIFF
--- a/src/py/run_program.rs
+++ b/src/py/run_program.rs
@@ -123,8 +123,8 @@ pub fn deserialize_and_run_program(
     let strict: bool = (flags & STRICT_MODE) != 0;
     let f: Box<dyn OperatorHandler<IntAllocator>> =
         Box::new(OperatorHandlerWithMode { f_lookup, strict });
-    let program: i32 = node_from_bytes(&mut allocator, program).unwrap();
-    let args: i32 = node_from_bytes(&mut allocator, args).unwrap();
+    let program = node_from_bytes(&mut allocator, program)?;
+    let args = node_from_bytes(&mut allocator, args)?;
 
     let r = run_program(
         &mut allocator,
@@ -138,12 +138,12 @@ pub fn deserialize_and_run_program(
     );
     match r {
         Ok(reduction) => {
-            let node_as_blob = node_to_bytes(&Node::new(&allocator, reduction.1)).unwrap();
+            let node_as_blob = node_to_bytes(&Node::new(&allocator, reduction.1))?;
             let node_as_bytes: Py<PyBytes> = PyBytes::new(py, &node_as_blob).into();
             Ok((reduction.0, node_as_bytes))
         }
         Err(eval_err) => {
-            let node_as_blob = node_to_bytes(&Node::new(&allocator, eval_err.0)).unwrap();
+            let node_as_blob = node_to_bytes(&Node::new(&allocator, eval_err.0))?;
             let msg = eval_err.1;
             let ctx: &PyDict = PyDict::new(py);
             ctx.set_item("msg", msg)?;

--- a/tests/generate-programs.py
+++ b/tests/generate-programs.py
@@ -128,5 +128,5 @@ softfork_wrap('programs/softfork-2.clvm', '0x00ffffff45')
 serialized_atom_overflow('programs/large-atom-1.hex', 0xffffffff)
 serialized_atom_overflow('programs/large-atom-2.hex', 0x3ffffffff)
 serialized_atom_overflow('programs/large-atom-3.hex', 0xffffffffff)
-serialized_atom_overflow('programs/large-atom-4.hex', 0xfffffffffff)
+serialized_atom_overflow('programs/large-atom-4.hex', 0x1ffffffffff)
 


### PR DESCRIPTION
This extends the test case generator to create serialized files with very large atoms (that are truncated on disk). This triggers the rust implementation to allocate a byte vector of 17179869183 bytes.

~~Somehow this doesn't seem to be a problem on 64 bit mac, but presumably this would fail on a 32 bit system.~~ This is a problem and causes CI to fail without the fix in this patch.

This patch replaces some `panic!()` with propagating errors up the call stack, as well as turning a few `unwrap()` into reporting errors as well.