### PR TITLE
enable LTO in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2018"
 name = "clvm_rs"
 crate-type = ["cdylib"]
 
+[profile.release]
+lto = true
+
 [dependencies.pyo3]
 version = "0.13.0"
 


### PR DESCRIPTION
it gives a small speed improvement (from 2 runs):
```
TOTAL: 127.244771 (-10.748750) -7.79 %
TOTAL: 130.604075 (-7.389446) -5.35 %
```