### PR TITLE
Max atom size

### DIFF
--- a/src/cost.rs
+++ b/src/cost.rs
@@ -1,6 +1,10 @@
 use crate::allocator::Allocator;
 use crate::reduction::EvalErr;
 
+// this must be small enough to prevent overflow in intermediate values in cost
+// computations.
+pub const MAX_ATOM_SIZE: usize = 8 * 1024 * 1024;
+
 pub type Cost = u64;
 
 pub fn check_cost<A: Allocator>(a: &A, cost: Cost, max_cost: Cost) -> Result<(), EvalErr<A::Ptr>> {

--- a/src/int_allocator.rs
+++ b/src/int_allocator.rs
@@ -1,4 +1,5 @@
 use crate::allocator::{Allocator, SExp};
+use crate::cost::MAX_ATOM_SIZE;
 use crate::err_utils::err;
 use crate::reduction::EvalErr;
 
@@ -59,6 +60,9 @@ impl Allocator for IntAllocator {
     type AtomBuf = IntAtomBuf;
 
     fn new_atom(&mut self, v: &[u8]) -> Result<Self::Ptr, EvalErr<Self::Ptr>> {
+        if v.len() > MAX_ATOM_SIZE {
+            return err(self.null(), "exceeded atom size limit");
+        }
         let start = self.u8_vec.len() as u32;
         if ((u32::MAX - start) as usize) < v.len() {
             return err(self.null(), "out of memory");

--- a/src/py/arc_allocator.rs
+++ b/src/py/arc_allocator.rs
@@ -1,4 +1,5 @@
 use crate::allocator::{Allocator, SExp};
+use crate::cost::MAX_ATOM_SIZE;
 use crate::err_utils::err;
 use crate::reduction::EvalErr;
 use std::sync::Arc;
@@ -53,6 +54,9 @@ impl Allocator for ArcAllocator {
     type AtomBuf = ArcAtomBuf;
 
     fn new_atom(&mut self, v: &[u8]) -> Result<Self::Ptr, EvalErr<Self::Ptr>> {
+        if v.len() > MAX_ATOM_SIZE {
+            return err(self.null(), "exceeded atom size limit");
+        }
         Ok(ArcSExp::Atom(ArcAtomBuf {
             buf: Arc::new(v.into()),
             start: 0,


### PR DESCRIPTION
This introduces a maximum size of atoms.

If atom sizes are unbounded, there would be a lot of places that would need additional overflow checks, anywhere we perform cost computations based on atom size for instance.

For example:
* https://github.com/Chia-Network/clvm_rs/blob/main/src/more_ops.rs#L369
* https://github.com/Chia-Network/clvm_rs/blob/main/src/more_ops.rs#L500

One risk of such approach is that the effective maximum atom size would be implied by which operations are performed and how costs are computed for those operations. For example, using multi-precision integers would avoid overflow of intermediate values and could raise the effective max atom size.

Proving that we could not overflow anywhere would be difficult and prone to errors.

Specifying an atom size upper limit explicitly has the benefit of:

1. simplify all logic that computes costs based on atom sizes, to know that all values are within reason and won't overflow
2. simplifies the documentation by simply stating the limit, rather than having to document individual limits for different operations.