### PR TITLE
use SHA256 from OpenSSL

### DIFF
--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -40,6 +40,7 @@ jobs:
           bash -exc '\
             echo $PATH && \
             curl -L https://sh.rustup.rs > rustup.rs && \
+            yum -y install openssl-devel && \
             chmod +x rustup.rs && \
             ./rustup.rs -y && \
             export PATH=$HOME/.cargo/bin:$PATH && \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -70,6 +70,7 @@ jobs:
             curl -L https://sh.rustup.rs > rustup.rs && \
             chmod +x rustup.rs && \
             ./rustup.rs -y && \
+            yum -y install openssl-devel && \
             export PATH=$HOME/.cargo/bin:$PATH && \
             rm -rf venv && \
             PY_VERSION=${{ matrix.python }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
+name = "cc"
+version = "1.0.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +90,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "num-bigint",
+ "openssl",
  "pyo3",
  "sha2",
 ]
@@ -125,6 +132,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,9 +154,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
 ]
@@ -280,6 +302,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "openssl"
+version = "0.10.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-src"
+version = "111.14.0+1.1.1j"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "055b569b5bd7e5462a1700f595c7c7d487691d73b5ce064176af7f9f0cbb80a9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "pairing"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +391,12 @@ checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
 dependencies = [
  "proc-macro-hack",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "proc-macro-hack"
@@ -481,6 +546,12 @@ name = "unindent"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f14ee04d9415b52b3aeab06258a3f07093182b88ba0f9b8d203f211a7a7d41c7"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,12 @@ default = ["extension-module"]
 
 [dependencies]
 hex = "0.4.2"
-sha2 = "0.8.0"
 lazy_static = "1.4.0"
 num-bigint = "0.3.1"
 bls12_381 = "0.4.0"
+
+[target.'cfg(windows)'.dependencies]
+sha2 = "0.8.0"
+
+[target.'cfg(unix)'.dependencies]
+openssl = "0.10.32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ bls12_381 = "0.4.0"
 sha2 = "0.8.0"
 
 [target.'cfg(unix)'.dependencies]
-openssl = "0.10.32"
+openssl = { version = "0.10.32", features = ["vendored"] }


### PR DESCRIPTION
This gives a material performance improvement:

```
          concat.hex mean: 0.712704 (+0.011270) +1.61 % (within uncertainty)
      count-even.hex mean: 0.030825 (-0.002555) -7.65 % (within uncertainty)
       factorial.hex mean: 0.180755 (+0.005640) +3.22 % (within uncertainty)
     hash-string.hex mean: 0.050723 (-0.001029) -1.99 % (within uncertainty)
       hash-tree.hex mean: 0.050442 (-0.017690) -25.96 %
     large-block.hex mean: 0.212357 (-0.115382) -35.21 %
 matrix-multiply.hex mean: 0.364929 (-0.006987) -1.88 % (within uncertainty)
       point-pow.hex mean: 1.336684 (-0.013341) -0.99 % (within uncertainty)
     pubkey-tree.hex mean: 0.492124 (-0.010853) -2.16 % (within uncertainty)
      shift-left.hex mean: 3.097096 (+0.027927) +0.91 % (within uncertainty)
     substr-tree.hex mean: 0.317756 (-0.003633) -1.13 % (within uncertainty)
          substr.hex mean: 0.012801 (-0.001186) -8.48 % (within uncertainty)
        sum-tree.hex mean: 0.533650 (-0.005785) -1.07 % (within uncertainty)
TOTAL: 36.964231 (-0.668024) -1.78 %
```