### PR TITLE
print cost of tests when running benchmarks

### DIFF
--- a/benchmark/run-benchmark.py
+++ b/benchmark/run-benchmark.py
@@ -165,6 +165,7 @@ if len(procs) > 0:
     print("")
 
 test_runs = {}
+test_costs = {}
 
 native_opcode_names_by_opcode = dict(
     ("op_%s" % OP_REWRITE.get(k, k), op)
@@ -224,6 +225,7 @@ for n in range(5):
         if fn in test_runs:
             test_runs[fn].append(counters['run_program'])
         else:
+            test_costs[fn] = cost
             test_runs[fn] = [counters['run_program']]
 
 sum_time = 0.0
@@ -245,6 +247,7 @@ for n, vals in sorted(test_runs.items()):
     print(Fore.MAGENTA, end='')
     for v in vals:
         print(' %s' % v, end='')
+    print(Fore.YELLOW + ' %10d' % test_costs[n], end='')
     print(Fore.RESET)
 
 print(Fore.GREEN + '      TOTAL:' + Style.RESET_ALL + ' %f s' % sum_time)


### PR DESCRIPTION
outputs like this:

```
          concat.hex mean: 2.497683 (+/- 0.005959)    2.491724 2.502847 2.498453 2.500432 2.494958   13074016
      count-even.hex mean: 0.075287 (+/- 0.001152)    0.075771 0.075615 0.074135 0.075523 0.075390     870038
       factorial.hex mean: 0.654951 (+/- 0.002521)    0.657472 0.653571 0.654270 0.653967 0.655475    4886327
     hash-string.hex mean: 0.123011 (+/- 0.004763)    0.127774 0.121981 0.121846 0.122059 0.121395          8
       hash-tree.hex mean: 0.223003 (+/- 0.036772)    0.259775 0.217905 0.210321 0.213759 0.213255    2310115
     large-block.hex mean: 1.094644 (+/- 0.006904)    1.098319 1.087740 1.095138 1.096398 1.095624   10755045
 matrix-multiply.hex mean: 1.016029 (+/- 0.004022)    1.017277 1.014122 1.019597 1.012007 1.017140   12514220
       point-pow.hex mean: 7.669887 (+/- 0.000332)    7.670163 7.669971 7.669860 7.669555 7.669884   11716773
     pubkey-tree.hex mean: 2.822611 (+/- 0.000080)    2.822691 2.822630 2.822628 2.822532 2.822572    4334963
      shift-left.hex mean: 9.563873 (+/- 0.098242)    9.662115 9.548446 9.528061 9.533286 9.547456   63772793
     substr-tree.hex mean: 0.910724 (+/- 0.006246)    0.904478 0.913301 0.906062 0.914387 0.915394    7951842
          substr.hex mean: 0.039820 (+/- 0.000270)    0.039550 0.040016 0.039877 0.039976 0.039683    3730017
        sum-tree.hex mean: 1.924266 (+/- 0.018625)    1.936480 1.905641 1.918151 1.937278 1.923778   19136481
```