### PR TITLE
Release GIL in `deserialize_and_run_program`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clvm_rs"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bls12_381",
  "hex",


### PR DESCRIPTION
This should allow use to use `ThreadPoolExecutor ` instead of `ProcessPoolExecutor` on `deserialize_and_run_program`. 