### PR TITLE
add a cargo config to help macos with linkage

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,11 @@
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
This lets you run `cargo build` on macos without having to go through the whole hoopla of maturin.