### PR TITLE
Simplify allocator

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -65,7 +65,7 @@ impl Allocator {
         r
     }
 
-    pub fn new_atom(&mut self, v: &[u8]) -> Result<NodePtr, EvalErr<NodePtr>> {
+    pub fn new_atom(&mut self, v: &[u8]) -> Result<NodePtr, EvalErr> {
         let start = self.u8_vec.len() as u32;
         if ((u32::MAX - start) as usize) < v.len() {
             return err(self.null(), "out of memory");
@@ -79,7 +79,7 @@ impl Allocator {
         Ok(-(self.atom_vec.len() as i32))
     }
 
-    pub fn new_pair(&mut self, first: NodePtr, rest: NodePtr) -> Result<NodePtr, EvalErr<NodePtr>> {
+    pub fn new_pair(&mut self, first: NodePtr, rest: NodePtr) -> Result<NodePtr, EvalErr> {
         let r = self.pair_vec.len() as i32;
         if self.pair_vec.len() == i32::MAX as usize {
             return err(self.null(), "too many pairs");
@@ -93,7 +93,7 @@ impl Allocator {
         node: NodePtr,
         start: u32,
         end: u32,
-    ) -> Result<NodePtr, EvalErr<NodePtr>> {
+    ) -> Result<NodePtr, EvalErr> {
         if node >= 0 {
             return err(node, "(internal error) substr expected atom, got pair");
         }

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -115,11 +115,11 @@ impl Allocator {
         Ok(-(self.atom_vec.len() as i32))
     }
 
-    pub fn atom<'a>(&'a self, node: &NodePtr) -> &'a [u8] {
-        if *node >= 0 {
+    pub fn atom(&self, node: NodePtr) -> &[u8] {
+        if node >= 0 {
             panic!("expected atom, got pair");
         }
-        let atom = self.atom_vec[(-*node - 1) as usize];
+        let atom = self.atom_vec[(-node - 1) as usize];
         &self.u8_vec[atom.start as usize..atom.end as usize]
     }
 
@@ -127,12 +127,12 @@ impl Allocator {
         &self.u8_vec[node.start as usize..node.end as usize]
     }
 
-    pub fn sexp(&self, node: &NodePtr) -> SExp {
-        if *node >= 0 {
-            let pair = self.pair_vec[*node as usize];
+    pub fn sexp(&self, node: NodePtr) -> SExp {
+        if node >= 0 {
+            let pair = self.pair_vec[node as usize];
             SExp::Pair(pair.first, pair.rest)
         } else {
-            let atom = self.atom_vec[(-*node - 1) as usize];
+            let atom = self.atom_vec[(-node - 1) as usize];
             SExp::Atom(atom)
         }
     }

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -88,12 +88,7 @@ impl Allocator {
         Ok(r)
     }
 
-    pub fn new_substr(
-        &mut self,
-        node: NodePtr,
-        start: u32,
-        end: u32,
-    ) -> Result<NodePtr, EvalErr> {
+    pub fn new_substr(&mut self, node: NodePtr, start: u32, end: u32) -> Result<NodePtr, EvalErr> {
         if node >= 0 {
             return err(node, "(internal error) substr expected atom, got pair");
         }

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,6 +1,8 @@
 use crate::err_utils::err;
 use crate::reduction::EvalErr;
 
+pub type NodePtr = i32;
+
 pub enum SExp {
     Atom(AtomBuf),
     Pair(NodePtr, NodePtr),
@@ -12,13 +14,17 @@ pub struct AtomBuf {
     end: u32,
 }
 
-#[derive(Clone, Copy)]
-pub struct IntPair {
-    first: i32,
-    rest: i32,
+impl AtomBuf {
+    pub fn is_empty(self) -> bool {
+        self.start == self.end
+    }
 }
 
-pub type NodePtr = i32;
+#[derive(Clone, Copy)]
+pub struct IntPair {
+    first: NodePtr,
+    rest: NodePtr,
+}
 
 pub struct Allocator {
     // this is effectively a grow-only stack where atoms are allocated. Atoms

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,9 +1,9 @@
 use crate::err_utils::err;
 use crate::reduction::EvalErr;
 
-pub enum SExp<T, B> {
-    Atom(B),
-    Pair(T, T),
+pub enum SExp {
+    Atom(AtomBuf),
+    Pair(NodePtr, NodePtr),
 }
 
 #[derive(Clone, Copy)]
@@ -121,7 +121,7 @@ impl Allocator {
         &self.u8_vec[node.start as usize..node.end as usize]
     }
 
-    pub fn sexp(&self, node: &NodePtr) -> SExp<NodePtr, AtomBuf> {
+    pub fn sexp(&self, node: &NodePtr) -> SExp {
         if *node >= 0 {
             let pair = self.pair_vec[*node as usize];
             SExp::Pair(pair.first, pair.rest)

--- a/src/core_ops.rs
+++ b/src/core_ops.rs
@@ -15,7 +15,7 @@ const LISTP_COST: Cost = 19;
 const EQ_BASE_COST: Cost = 117;
 const EQ_COST_PER_BYTE: Cost = 1;
 
-pub fn op_if(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response<NodePtr> {
+pub fn op_if(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     let args = Node::new(a, input);
     check_arg_count(&args, 3, "i")?;
     let cond = args.first()?;
@@ -26,7 +26,7 @@ pub fn op_if(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response<Nod
     Ok(Reduction(IF_COST, chosen_node.first()?.node))
 }
 
-pub fn op_cons(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response<NodePtr> {
+pub fn op_cons(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     let args = Node::new(a, input);
     check_arg_count(&args, 2, "c")?;
     let a1 = args.first()?;
@@ -37,19 +37,19 @@ pub fn op_cons(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response<N
     Ok(Reduction(CONS_COST, r))
 }
 
-pub fn op_first(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response<NodePtr> {
+pub fn op_first(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     let args = Node::new(a, input);
     check_arg_count(&args, 1, "f")?;
     Ok(Reduction(FIRST_COST, args.first()?.first()?.node))
 }
 
-pub fn op_rest(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response<NodePtr> {
+pub fn op_rest(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     let args = Node::new(a, input);
     check_arg_count(&args, 1, "r")?;
     Ok(Reduction(REST_COST, args.first()?.rest()?.node))
 }
 
-pub fn op_listp(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response<NodePtr> {
+pub fn op_listp(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     let args = Node::new(a, input);
     check_arg_count(&args, 1, "l")?;
     match args.first()?.pair() {
@@ -58,12 +58,12 @@ pub fn op_listp(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response<
     }
 }
 
-pub fn op_raise(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response<NodePtr> {
+pub fn op_raise(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     let args = Node::new(a, input);
     args.err("clvm raise")
 }
 
-pub fn op_eq(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response<NodePtr> {
+pub fn op_eq(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     let args = Node::new(a, input);
     check_arg_count(&args, 2, "=")?;
     let a0 = args.first()?;

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -1,9 +1,9 @@
-use crate::allocator::{Allocator, NodePtr};
+use crate::allocator::Allocator;
 use crate::reduction::EvalErr;
 
 pub type Cost = u64;
 
-pub fn check_cost(a: &Allocator, cost: Cost, max_cost: Cost) -> Result<(), EvalErr<NodePtr>> {
+pub fn check_cost(a: &Allocator, cost: Cost, max_cost: Cost) -> Result<(), EvalErr> {
     if cost > max_cost {
         Err(EvalErr(a.null(), "cost exceeded".into()))
     } else {

--- a/src/err_utils.rs
+++ b/src/err_utils.rs
@@ -1,15 +1,6 @@
-use crate::allocator::{Allocator, AtomBuf, NodePtr};
+use crate::allocator::NodePtr;
 use crate::reduction::EvalErr;
 
 pub fn err<T>(node: NodePtr, msg: &str) -> Result<T, EvalErr> {
     Err(EvalErr(node, msg.into()))
-}
-
-// TODO: if we pass in NodePtr instead of AtomBuf, we don't have to allocate a
-// new atom, and we could avoid the akward possibility of failing to allocate
-// the error message
-pub fn u8_err<T>(allocator: &mut Allocator, o: &AtomBuf, msg: &str) -> Result<T, EvalErr> {
-    let op = allocator.buf(o);
-    let buf = op.to_vec();
-    err(allocator.new_atom(&buf)?, msg)
 }

--- a/src/err_utils.rs
+++ b/src/err_utils.rs
@@ -1,14 +1,14 @@
 use crate::allocator::{Allocator, AtomBuf, NodePtr};
 use crate::reduction::EvalErr;
 
-pub fn err<T, P>(node: P, msg: &str) -> Result<T, EvalErr<P>> {
+pub fn err<T>(node: NodePtr, msg: &str) -> Result<T, EvalErr> {
     Err(EvalErr(node, msg.into()))
 }
 
 // TODO: if we pass in NodePtr instead of AtomBuf, we don't have to allocate a
 // new atom, and we could avoid the akward possibility of failing to allocate
 // the error message
-pub fn u8_err<T>(allocator: &mut Allocator, o: &AtomBuf, msg: &str) -> Result<T, EvalErr<NodePtr>> {
+pub fn u8_err<T>(allocator: &mut Allocator, o: &AtomBuf, msg: &str) -> Result<T, EvalErr> {
     let op = allocator.buf(o);
     let buf = op.to_vec();
     err(allocator.new_atom(&buf)?, msg)

--- a/src/more_ops.rs
+++ b/src/more_ops.rs
@@ -101,7 +101,7 @@ fn new_atom_and_cost(a: &mut Allocator, cost: Cost, buf: &[u8]) -> Response<Node
 }
 
 fn malloc_cost(a: &Allocator, cost: Cost, ptr: NodePtr) -> Reduction<NodePtr> {
-    let c = a.atom(&ptr).len() as Cost * MALLOC_COST_PER_BYTE;
+    let c = a.atom(ptr).len() as Cost * MALLOC_COST_PER_BYTE;
     Reduction(cost + c, ptr)
 }
 
@@ -224,7 +224,7 @@ fn test_op_unknown(buf: &[u8], a: &mut Allocator, n: NodePtr) -> Response<NodePt
     use crate::allocator::SExp;
 
     let buf = a.new_atom(buf)?;
-    let abuf = match a.sexp(&buf) {
+    let abuf = match a.sexp(buf) {
         SExp::Atom(abuf) => abuf,
         _ => panic!("shouldn't happen"),
     };
@@ -448,7 +448,7 @@ pub fn op_divmod(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response
         let q1 = ptr_from_number(a, &q)?;
         let r1 = ptr_from_number(a, &r)?;
 
-        let c = (a.atom(&q1).len() + a.atom(&r1).len()) as Cost * MALLOC_COST_PER_BYTE;
+        let c = (a.atom(q1).len() + a.atom(r1).len()) as Cost * MALLOC_COST_PER_BYTE;
         let r: NodePtr = a.new_pair(q1, r1)?;
         Ok(Reduction(cost + c, r))
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,4 +1,4 @@
-use super::allocator::{Allocator, AtomBuf, NodePtr, SExp};
+use super::allocator::{Allocator, NodePtr, SExp};
 use std::fmt;
 
 pub struct Node<'a> {
@@ -15,7 +15,7 @@ impl<'a> Node<'a> {
         Node::new(self.allocator, node)
     }
 
-    pub fn sexp(&self) -> SExp<NodePtr, AtomBuf> {
+    pub fn sexp(&self) -> SExp {
         self.allocator.sexp(&self.node)
     }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -16,12 +16,12 @@ impl<'a> Node<'a> {
     }
 
     pub fn sexp(&self) -> SExp {
-        self.allocator.sexp(&self.node)
+        self.allocator.sexp(self.node)
     }
 
     pub fn atom(&'a self) -> Option<&'a [u8]> {
         match self.sexp() {
-            SExp::Atom(_) => Some(self.allocator.atom(&self.node)),
+            SExp::Atom(_) => Some(self.allocator.atom(self.node)),
             _ => None,
         }
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -35,7 +35,7 @@ impl<'a> Node<'a> {
 
     pub fn nullp(&self) -> bool {
         match self.sexp() {
-            SExp::Atom(a) => self.allocator.buf(&a).is_empty(),
+            SExp::Atom(a) => a.is_empty(),
             _ => false,
         }
     }

--- a/src/number.rs
+++ b/src/number.rs
@@ -8,7 +8,7 @@ pub type Number = BigInt;
 pub fn ptr_from_number(
     allocator: &mut Allocator,
     item: &Number,
-) -> Result<NodePtr, EvalErr<NodePtr>> {
+) -> Result<NodePtr, EvalErr> {
     let bytes: Vec<u8> = item.to_signed_bytes_be();
     let mut slice = bytes.as_slice();
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -5,10 +5,7 @@ use crate::reduction::EvalErr;
 use num_bigint::BigInt;
 pub type Number = BigInt;
 
-pub fn ptr_from_number(
-    allocator: &mut Allocator,
-    item: &Number,
-) -> Result<NodePtr, EvalErr> {
+pub fn ptr_from_number(allocator: &mut Allocator, item: &Number) -> Result<NodePtr, EvalErr> {
     let bytes: Vec<u8> = item.to_signed_bytes_be();
     let mut slice = bytes.as_slice();
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -46,54 +46,54 @@ fn test_ptr_from_number() {
     let num = number_from_u8(&[0]);
     let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "0");
-    assert_eq!(a.atom(&ptr).len(), 0);
+    assert_eq!(a.atom(ptr).len(), 0);
 
     let num = number_from_u8(&[1]);
     let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "1");
-    assert_eq!(&[1], &a.atom(&ptr));
+    assert_eq!(&[1], &a.atom(ptr));
 
     // leading zeroes are redundant
     let num = number_from_u8(&[0, 0, 0, 1]);
     let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "1");
-    assert_eq!(&[1], &a.atom(&ptr));
+    assert_eq!(&[1], &a.atom(ptr));
 
     let num = number_from_u8(&[0x00, 0x00, 0x80]);
     let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "128");
-    assert_eq!(&[0x00, 0x80], &a.atom(&ptr));
+    assert_eq!(&[0x00, 0x80], &a.atom(ptr));
 
     // A leading zero is necessary to encode a positive number with the
     // penultimate byte's most significant bit set
     let num = number_from_u8(&[0x00, 0xff]);
     let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "255");
-    assert_eq!(&[0x00, 0xff], &a.atom(&ptr));
+    assert_eq!(&[0x00, 0xff], &a.atom(ptr));
 
     let num = number_from_u8(&[0x7f, 0xff]);
     let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "32767");
-    assert_eq!(&[0x7f, 0xff], &a.atom(&ptr));
+    assert_eq!(&[0x7f, 0xff], &a.atom(ptr));
 
     // the first byte is redundant, it's still -1
     let num = number_from_u8(&[0xff, 0xff]);
     let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "-1");
-    assert_eq!(&[0xff], &a.atom(&ptr));
+    assert_eq!(&[0xff], &a.atom(ptr));
 
     let num = number_from_u8(&[0xff]);
     let ptr = ptr_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "-1");
-    assert_eq!(&[0xff], &a.atom(&ptr));
+    assert_eq!(&[0xff], &a.atom(ptr));
 
     let num = number_from_u8(&[0x00, 0x80, 0x00]);
     assert_eq!(format!("{}", num), "32768");
     let ptr = ptr_from_number(&mut a, &num).unwrap();
-    assert_eq!(&[0x00, 0x80, 0x00], &a.atom(&ptr));
+    assert_eq!(&[0x00, 0x80, 0x00], &a.atom(ptr));
 
     let num = number_from_u8(&[0x00, 0x40, 0x00]);
     assert_eq!(format!("{}", num), "16384");
     let ptr = ptr_from_number(&mut a, &num).unwrap();
-    assert_eq!(&[0x40, 0x00], &a.atom(&ptr));
+    assert_eq!(&[0x40, 0x00], &a.atom(ptr));
 }

--- a/src/op_utils.rs
+++ b/src/op_utils.rs
@@ -81,10 +81,7 @@ pub fn atom<'a>(args: &'a Node, op_name: &str) -> Result<&'a [u8], EvalErr> {
     }
 }
 
-pub fn two_ints(
-    args: &Node,
-    op_name: &str,
-) -> Result<(Number, usize, Number, usize), EvalErr> {
+pub fn two_ints(args: &Node, op_name: &str) -> Result<(Number, usize, Number, usize), EvalErr> {
     check_arg_count(args, 2, op_name)?;
     let a0 = args.first()?;
     let a1 = args.rest()?.first()?;

--- a/src/op_utils.rs
+++ b/src/op_utils.rs
@@ -1,10 +1,9 @@
-use crate::allocator::NodePtr;
 use crate::err_utils::err;
 use crate::node::Node;
 use crate::number::{number_from_u8, Number};
 use crate::reduction::EvalErr;
 
-pub fn check_arg_count(args: &Node, expected: usize, name: &str) -> Result<(), EvalErr<NodePtr>> {
+pub fn check_arg_count(args: &Node, expected: usize, name: &str) -> Result<(), EvalErr> {
     if arg_count(args, expected) != expected {
         args.err(&format!(
             "{} takes exactly {} argument{}",
@@ -67,7 +66,7 @@ fn test_arg_count() {
     assert_eq!(arg_count(&count_3_args, 4), 3);
 }
 
-pub fn int_atom<'a>(args: &'a Node, op_name: &str) -> Result<&'a [u8], EvalErr<NodePtr>> {
+pub fn int_atom<'a>(args: &'a Node, op_name: &str) -> Result<&'a [u8], EvalErr> {
     match args.atom() {
         Some(a) => Ok(a),
         _ => args.err(&format!("{} requires int args", op_name)),
@@ -75,7 +74,7 @@ pub fn int_atom<'a>(args: &'a Node, op_name: &str) -> Result<&'a [u8], EvalErr<N
 }
 
 // rename to atom()
-pub fn atom<'a>(args: &'a Node, op_name: &str) -> Result<&'a [u8], EvalErr<NodePtr>> {
+pub fn atom<'a>(args: &'a Node, op_name: &str) -> Result<&'a [u8], EvalErr> {
     match args.atom() {
         Some(a) => Ok(a),
         _ => args.err(&format!("{} on list", op_name)),
@@ -85,7 +84,7 @@ pub fn atom<'a>(args: &'a Node, op_name: &str) -> Result<&'a [u8], EvalErr<NodeP
 pub fn two_ints(
     args: &Node,
     op_name: &str,
-) -> Result<(Number, usize, Number, usize), EvalErr<NodePtr>> {
+) -> Result<(Number, usize, Number, usize), EvalErr> {
     check_arg_count(args, 2, op_name)?;
     let a0 = args.first()?;
     let a1 = args.rest()?.first()?;
@@ -174,7 +173,7 @@ fn test_i32_from_u8() {
     assert_eq!(i32_from_u8(&[0x7d, 0xcc, 0x55, 0x88, 0xf3]), None);
 }
 
-pub fn i32_atom(args: &Node, op_name: &str) -> Result<i32, EvalErr<NodePtr>> {
+pub fn i32_atom(args: &Node, op_name: &str) -> Result<i32, EvalErr> {
     let buf = match args.atom() {
         Some(a) => a,
         _ => {
@@ -191,21 +190,21 @@ pub fn i32_atom(args: &Node, op_name: &str) -> Result<i32, EvalErr<NodePtr>> {
 }
 
 impl<'a> Node<'a> {
-    pub fn first(&self) -> Result<Node<'a>, EvalErr<NodePtr>> {
+    pub fn first(&self) -> Result<Node<'a>, EvalErr> {
         match self.pair() {
             Some((p1, _)) => Ok(self.with_node(p1.node)),
             _ => self.err("first of non-cons"),
         }
     }
 
-    pub fn rest(&self) -> Result<Node<'a>, EvalErr<NodePtr>> {
+    pub fn rest(&self) -> Result<Node<'a>, EvalErr> {
         match self.pair() {
             Some((_, p2)) => Ok(self.with_node(p2.node)),
             _ => self.err("rest of non-cons"),
         }
     }
 
-    pub fn err<T>(&self, msg: &str) -> Result<T, EvalErr<NodePtr>> {
+    pub fn err<T>(&self, msg: &str) -> Result<T, EvalErr> {
         err(self.node, msg)
     }
 }

--- a/src/py/f_table.rs
+++ b/src/py/f_table.rs
@@ -10,7 +10,7 @@ use crate::more_ops::{
 };
 use crate::reduction::Response;
 
-type OpFn = fn(&mut Allocator, NodePtr, Cost) -> Response<NodePtr>;
+type OpFn = fn(&mut Allocator, NodePtr, Cost) -> Response;
 
 pub type FLookup = [Option<OpFn>; 256];
 

--- a/src/py/lazy_node.rs
+++ b/src/py/lazy_node.rs
@@ -23,7 +23,7 @@ impl ToPyObject for LazyNode {
 impl LazyNode {
     #[getter(pair)]
     pub fn pair(&self, py: Python) -> PyResult<Option<PyObject>> {
-        match &self.allocator.sexp(&self.node) {
+        match &self.allocator.sexp(self.node) {
             SExp::Pair(p1, p2) => {
                 let r1 = Self::new(self.allocator.clone(), *p1);
                 let r2 = Self::new(self.allocator.clone(), *p2);
@@ -36,7 +36,7 @@ impl LazyNode {
 
     #[getter(atom)]
     pub fn atom(&self, py: Python) -> Option<PyObject> {
-        match &self.allocator.sexp(&self.node) {
+        match &self.allocator.sexp(self.node) {
             SExp::Atom(atom) => Some(PyBytes::new(py, self.allocator.buf(atom)).into()),
             _ => None,
         }

--- a/src/py/run_program.rs
+++ b/src/py/run_program.rs
@@ -27,13 +27,13 @@ impl OperatorHandler for OperatorHandlerWithMode {
         &self,
         allocator: &mut Allocator,
         o: AtomBuf,
-        argument_list: &NodePtr,
+        argument_list: NodePtr,
         max_cost: Cost,
     ) -> Response<NodePtr> {
         let op = &allocator.buf(&o);
         if op.len() == 1 {
             if let Some(f) = self.f_lookup[op[0] as usize] {
-                return f(allocator, *argument_list, max_cost);
+                return f(allocator, argument_list, max_cost);
             }
         }
         if self.strict {
@@ -41,7 +41,7 @@ impl OperatorHandler for OperatorHandlerWithMode {
             let op_arg = allocator.new_atom(&buf)?;
             err(op_arg, "unimplemented operator")
         } else {
-            op_unknown(allocator, o, *argument_list, max_cost)
+            op_unknown(allocator, o, argument_list, max_cost)
         }
     }
 }
@@ -129,8 +129,8 @@ pub fn deserialize_and_run_program(
     let r = py.allow_threads(|| {
         run_program(
             &mut allocator,
-            &program,
-            &args,
+            program,
+            args,
             quote_kw,
             apply_kw,
             max_cost,
@@ -196,8 +196,8 @@ pub fn deserialize_and_run_program2(
     let r = py.allow_threads(|| {
         run_program(
             &mut allocator,
-            &program,
-            &args,
+            program,
+            args,
             quote_kw,
             apply_kw,
             max_cost,

--- a/src/py/run_program.rs
+++ b/src/py/run_program.rs
@@ -29,7 +29,7 @@ impl OperatorHandler for OperatorHandlerWithMode {
         o: NodePtr,
         argument_list: NodePtr,
         max_cost: Cost,
-    ) -> Response<NodePtr> {
+    ) -> Response {
         let b = &allocator.atom(o);
         if b.len() == 1 {
             if let Some(f) = self.f_lookup[b[0] as usize] {

--- a/src/py/run_program.rs
+++ b/src/py/run_program.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use crate::allocator::{Allocator, AtomBuf, NodePtr};
+use crate::allocator::{Allocator, NodePtr};
 use crate::cost::Cost;
 use crate::err_utils::err;
 use crate::more_ops::op_unknown;
@@ -26,20 +26,18 @@ impl OperatorHandler for OperatorHandlerWithMode {
     fn op(
         &self,
         allocator: &mut Allocator,
-        o: AtomBuf,
+        o: NodePtr,
         argument_list: NodePtr,
         max_cost: Cost,
     ) -> Response<NodePtr> {
-        let op = &allocator.buf(&o);
-        if op.len() == 1 {
-            if let Some(f) = self.f_lookup[op[0] as usize] {
+        let b = &allocator.atom(o);
+        if b.len() == 1 {
+            if let Some(f) = self.f_lookup[b[0] as usize] {
                 return f(allocator, argument_list, max_cost);
             }
         }
         if self.strict {
-            let buf = op.to_vec();
-            let op_arg = allocator.new_atom(&buf)?;
-            err(op_arg, "unimplemented operator")
+            err(o, "unimplemented operator")
         } else {
             op_unknown(allocator, o, argument_list, max_cost)
         }

--- a/src/reduction.rs
+++ b/src/reduction.rs
@@ -5,6 +5,6 @@ use crate::cost::Cost;
 pub struct EvalErr(pub NodePtr, pub String);
 
 #[derive(Debug, PartialEq)]
-pub struct Reduction<T>(pub Cost, pub T);
+pub struct Reduction(pub Cost, pub NodePtr);
 
-pub type Response<T> = Result<Reduction<T>, EvalErr>;
+pub type Response = Result<Reduction, EvalErr>;

--- a/src/reduction.rs
+++ b/src/reduction.rs
@@ -1,9 +1,10 @@
 use crate::cost::Cost;
+use crate::allocator::NodePtr;
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct EvalErr<T>(pub T, pub String);
+pub struct EvalErr(pub NodePtr, pub String);
 
 #[derive(Debug, PartialEq)]
 pub struct Reduction<T>(pub Cost, pub T);
 
-pub type Response<T> = Result<Reduction<T>, EvalErr<T>>;
+pub type Response<T> = Result<Reduction<T>, EvalErr>;

--- a/src/reduction.rs
+++ b/src/reduction.rs
@@ -1,5 +1,5 @@
-use crate::cost::Cost;
 use crate::allocator::NodePtr;
+use crate::cost::Cost;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct EvalErr(pub NodePtr, pub String);

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -18,13 +18,8 @@ const TRAVERSE_COST_PER_ZERO_BYTE: Cost = 4;
 const TRAVERSE_COST_PER_BIT: Cost = 4;
 
 pub trait OperatorHandler {
-    fn op(
-        &self,
-        allocator: &mut Allocator,
-        op: NodePtr,
-        args: NodePtr,
-        max_cost: Cost,
-    ) -> Response<NodePtr>;
+    fn op(&self, allocator: &mut Allocator, op: NodePtr, args: NodePtr, max_cost: Cost)
+        -> Response;
 }
 
 pub type PreEval =
@@ -91,7 +86,7 @@ const fn first_non_zero(buf: &[u8]) -> usize {
     c
 }
 
-fn traverse_path(allocator: &Allocator, node_index: &[u8], args: NodePtr) -> Response<NodePtr> {
+fn traverse_path(allocator: &Allocator, node_index: &[u8], args: NodePtr) -> Response {
     let mut arg_list: NodePtr = args;
 
     // find first non-zero byte
@@ -229,8 +224,7 @@ where
         let (op_node, op_list) = match self.allocator.sexp(program) {
             // the program is just a bitfield path through the args tree
             SExp::Atom(path) => {
-                let r: Reduction<NodePtr> =
-                    traverse_path(self.allocator, self.allocator.buf(&path), args)?;
+                let r: Reduction = traverse_path(self.allocator, self.allocator.buf(&path), args)?;
                 self.push(r.1);
                 return Ok(r.0);
             }
@@ -311,12 +305,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn run_program(
-        &mut self,
-        program: NodePtr,
-        args: NodePtr,
-        max_cost: Cost,
-    ) -> Response<NodePtr> {
+    pub fn run_program(&mut self, program: NodePtr, args: NodePtr, max_cost: Cost) -> Response {
         self.val_stack = vec![self.allocator.new_pair(program, args)?];
         self.op_stack = vec![Operation::Eval];
 
@@ -367,7 +356,7 @@ pub fn run_program(
     max_cost: Cost,
     operator_lookup: Box<dyn OperatorHandler>,
     pre_eval: Option<PreEval>,
-) -> Response<NodePtr>
+) -> Response
 where
     NodePtr: 'static,
 {

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -56,7 +56,7 @@ pub fn node_to_stream(node: &Node, f: &mut dyn Write) -> std::io::Result<()> {
     let a = node.allocator;
     while !values.is_empty() {
         let v = values.pop().unwrap();
-        let n = a.sexp(&v);
+        let n = a.sexp(v);
         match n {
             SExp::Atom(atom_ptr) => {
                 let atom = a.buf(&atom_ptr);

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -127,8 +127,8 @@ enum ParseOp {
     Cons,
 }
 
-impl<T> std::convert::From<EvalErr<T>> for std::io::Error {
-    fn from(v: EvalErr<T>) -> Self {
+impl std::convert::From<EvalErr> for std::io::Error {
+    fn from(v: EvalErr) -> Self {
         Self::new(ErrorKind::Other, v.1)
     }
 }


### PR DESCRIPTION
With the `ArcAllocator` removed, ownership is implified and we can pass around `NodePtr` instead of `AtomBuf`. this simplifies a few things.

Additionally, since `NodePtr` is an `i32`, we shouldn't be passing it around by reference, but just copy it instead.

Now that we only have a single allocator, `SExp` and `EvalErr` no longer needs to be templates.

These are mostly independent commits, sharing the common dependency that they are simplifications of not having the allocator be a template anymore.