### PR TITLE
exclude the python binding when building 'cargo test'

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -229,4 +229,4 @@ jobs:
             toolchain: stable
             components: rustfmt, clippy
       - name: cargo test
-        run: cargo test --no-default-features
+        run: cargo test

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Note that for now, you must use the `use_clvm_rs` branch of `clvm`.
 
 The rust code replaces `run_program` and `CLVMObject`.
 
-In order to run the unit tests, one has to pass `--no-default-features` to `cargo test`:
+In order to run the unit tests, run:
 
 ```
-cargo test --no-default-features
+cargo test
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod more_ops;
 mod node;
 mod number;
 mod op_utils;
+#[cfg(not(test))]
 mod py;
 mod reduction;
 mod run_program;

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -37,7 +37,7 @@ enum Operation {
 }
 
 // `run_program` has two stacks: the operand stack (of `Node` objects) and the
-// operator stack (of RpcOperators)
+// operator stack (of Operation)
 
 pub struct RunProgramContext<'a> {
     allocator: &'a mut Allocator,


### PR DESCRIPTION
to not need `--no-default-features` option