### PR TITLE
simplify handling of CREATE_COIN hint

### DIFF
--- a/src/gen/conditions.rs
+++ b/src/gen/conditions.rs
@@ -131,7 +131,7 @@ fn parse_args(
             if let Ok(c) = rest(a, c) {
                 if let Ok(param) = first(a, c) {
                     if let SExp::Atom(b) = a.sexp(param) {
-                        if a.buf(&b).len() == 32 {
+                        if a.buf(&b).len() <= 32 {
                             return Ok(Condition::CreateCoin(puzzle_hash, amount, param));
                         }
                     }

--- a/src/py/run_generator.rs
+++ b/src/py/run_generator.rs
@@ -98,17 +98,14 @@ fn convert_spend(
 
     let mut new_coins = Vec::<PyConditionWithArgs>::new();
     for new_coin in spend_cond.create_coin {
-        let mut cwa = PyConditionWithArgs {
+        new_coins.push(PyConditionWithArgs {
             opcode: CREATE_COIN,
             vars: vec![
                 PyBytes::new(py, &new_coin.puzzle_hash).into(),
                 int_to_pybytes(py, new_coin.amount),
+                node_to_pybytes(py, a, new_coin.hint),
             ],
-        };
-        if new_coin.hint != a.null() {
-            cwa.vars.push(node_to_pybytes(py, a, new_coin.hint));
-        }
-        new_coins.push(cwa);
+        });
     }
     if !new_coins.is_empty() {
         ordered.insert(CREATE_COIN, new_coins);

--- a/tests/test-generators.py
+++ b/tests/test-generators.py
@@ -19,7 +19,14 @@ for g in glob.glob('generators/*.clvm'):
             output += f"  {c[0]}\n"
             for cwa in sorted(c[1], key=lambda x: (x.opcode, x.vars)):
                 output += f"    {cwa.opcode}"
-                for a in cwa.vars:
+
+                # special case to omit an empty hint from CREATE_COIN, to preserve the
+                # output from the test cases not using a hint
+                var = list(cwa.vars)
+                if cwa.opcode == 51 and len(cwa.vars) == 3 and len(cwa.vars[2]) == 0:
+                    var.pop(2)
+
+                for a in var:
                     output += f" {a.hex()}"
                 output += "\n"
     if error_code:


### PR DESCRIPTION
to always include it in what's returned to python. Then it's up to the caller to ignore empty hints