### PR TITLE
split out the different features enabled by strict mode

### DIFF
--- a/benchmark/run-benchmark.py
+++ b/benchmark/run-benchmark.py
@@ -8,7 +8,7 @@ import time
 import random
 from clvm import KEYWORD_FROM_ATOM, KEYWORD_TO_ATOM
 from clvm.operators import OP_REWRITE
-from clvm_rs import run_chia_program, STRICT_MODE
+from clvm_rs import run_chia_program
 from colorama import init, Fore, Style
 
 init()

--- a/fuzz/fuzz_targets/run_program.rs
+++ b/fuzz/fuzz_targets/run_program.rs
@@ -15,7 +15,7 @@ fuzz_target!(|data: &[u8]| {
         Ok(r) => r,
     };
     let args = allocator.null();
-    let dialect = ChiaDialect::new(false);
+    let dialect = ChiaDialect::new(0);
 
     let Reduction(_cost, _node) = match run_program(&mut allocator, &dialect, program, args, 12000000000 as Cost, None) {
         Err(_) => { return; },

--- a/src/gen/condition_sanitizers.rs
+++ b/src/gen/condition_sanitizers.rs
@@ -86,7 +86,7 @@ pub fn sanitize_announce_msg(
 }
 
 #[cfg(test)]
-use crate::run_program::STRICT_MODE;
+use crate::gen::flags::COND_CANON_INTS;
 
 #[cfg(test)]
 fn zero_vec(len: usize) -> Vec<u8> {
@@ -168,8 +168,9 @@ fn amount_tester(buf: &[u8], flags: u32) -> Result<u64, ValidationErr> {
 
 #[test]
 fn test_sanitize_amount() {
-    for flags in &[0, STRICT_MODE] {
+    for flags in &[0, COND_CANON_INTS] {
         // negative amounts are not allowed
+        // regardless of flags
         assert_eq!(
             amount_tester(&[0x80], *flags).unwrap_err().1,
             ErrorCode::InvalidCoinAmount
@@ -186,7 +187,7 @@ fn test_sanitize_amount() {
         // leading zeros are somtimes necessary to make values positive
         assert_eq!(amount_tester(&[0, 0xff], *flags), Ok(0xff));
         // but are stripped when they are redundant
-        if (flags & STRICT_MODE) != 0 {
+        if (flags & COND_CANON_INTS) != 0 {
             assert_eq!(
                 amount_tester(&[0, 0, 0, 0xff], *flags).unwrap_err().1,
                 ErrorCode::InvalidCoinAmount
@@ -243,7 +244,7 @@ fn height_tester(buf: &[u8], flags: u32) -> Result<u32, ValidationErr> {
 
 #[test]
 fn test_parse_height() {
-    for flags in &[0, STRICT_MODE] {
+    for flags in &[0, COND_CANON_INTS] {
         // negative heights can be ignored
         assert_eq!(height_tester(&[0x80], *flags), Ok(0));
         assert_eq!(height_tester(&[0xff], *flags), Ok(0));
@@ -252,7 +253,7 @@ fn test_parse_height() {
         // leading zeros are somtimes necessary to make values positive
         assert_eq!(height_tester(&[0, 0xff], *flags), Ok(0xff));
         // but are stripped when they are redundant
-        if (flags & STRICT_MODE) != 0 {
+        if (flags & COND_CANON_INTS) != 0 {
             assert_eq!(
                 height_tester(&[0, 0, 0, 0xff], *flags).unwrap_err().1,
                 ErrorCode::AssertHeightAbsolute
@@ -328,7 +329,7 @@ fn seconds_tester(buf: &[u8], flags: u32) -> Result<u64, ValidationErr> {
 
 #[test]
 fn test_parse_seconds() {
-    for flags in &[0, STRICT_MODE] {
+    for flags in &[0, COND_CANON_INTS] {
         // negative seconds can be ignored
         assert_eq!(seconds_tester(&[0x80], *flags), Ok(0));
         assert_eq!(seconds_tester(&[0xff], *flags), Ok(0));
@@ -337,7 +338,7 @@ fn test_parse_seconds() {
         // leading zeros are somtimes necessary to make values positive
         assert_eq!(seconds_tester(&[0, 0xff], *flags), Ok(0xff));
         // but are stripped when they are redundant
-        if (flags & STRICT_MODE) != 0 {
+        if (flags & COND_CANON_INTS) != 0 {
             assert_eq!(
                 seconds_tester(&[0, 0, 0, 0xff], *flags).unwrap_err().1,
                 ErrorCode::AssertSecondsAbsolute

--- a/src/gen/conditions.rs
+++ b/src/gen/conditions.rs
@@ -7,6 +7,7 @@ use super::sanitize_int::sanitize_uint;
 use super::validation_error::{first, next, rest, ErrorCode, ValidationErr};
 use crate::allocator::{Allocator, NodePtr, SExp};
 use crate::cost::Cost;
+use crate::gen::flags::NO_UNKNOWN_CONDS;
 use crate::gen::opcodes::{
     parse_opcode, ConditionOpcode, AGG_SIG_COST, AGG_SIG_ME, AGG_SIG_UNSAFE,
     ASSERT_COIN_ANNOUNCEMENT, ASSERT_HEIGHT_ABSOLUTE, ASSERT_HEIGHT_RELATIVE, ASSERT_MY_AMOUNT,
@@ -15,7 +16,6 @@ use crate::gen::opcodes::{
     CREATE_COIN_COST, CREATE_PUZZLE_ANNOUNCEMENT, RESERVE_FEE,
 };
 use crate::op_utils::u64_from_bytes;
-use crate::run_program::STRICT_MODE;
 use crate::sha2::Sha256;
 use std::cmp::max;
 use std::collections::HashSet;
@@ -386,7 +386,7 @@ fn parse_spend_conditions(
         let op = match parse_opcode(a, first(a, c)?) {
             None => {
                 // in strict mode we don't allow unknown conditions
-                if (flags & STRICT_MODE) != 0 {
+                if (flags & NO_UNKNOWN_CONDS) != 0 {
                     return Err(ValidationErr(c, ErrorCode::InvalidConditionOpcode));
                 }
                 // in non-strict mode, we just ignore unknown conditions

--- a/src/gen/flags.rs
+++ b/src/gen/flags.rs
@@ -1,0 +1,8 @@
+// flags controlling to condition parsing
+
+// in conditions output, integers must use canonical encoding (i.e. no redundant
+// leading zeros)
+pub const COND_CANON_INTS: u32 = 0x010000;
+
+// unknown condition codes are disallowed
+pub const NO_UNKNOWN_CONDS: u32 = 0x20000;

--- a/src/gen/mod.rs
+++ b/src/gen/mod.rs
@@ -1,6 +1,7 @@
 mod coin_id;
 mod condition_sanitizers;
 pub mod conditions;
+pub mod flags;
 pub mod opcodes;
 mod rangeset;
 mod sanitize_int;

--- a/src/gen/sanitize_int.rs
+++ b/src/gen/sanitize_int.rs
@@ -1,7 +1,7 @@
 use super::rangeset::RangeSet;
 use super::validation_error::{atom, ErrorCode, ValidationErr};
 use crate::allocator::{Allocator, AtomBuf, NodePtr, SExp};
-use crate::run_program::STRICT_MODE;
+use crate::gen::flags::COND_CANON_INTS;
 
 fn count_zeros_impl(buf: &[u8]) -> usize {
     let mut ret: usize = 0;
@@ -109,7 +109,7 @@ pub fn sanitize_uint<'a>(
         i -= 1;
     }
 
-    if (flags & STRICT_MODE) != 0 && i > 0 {
+    if (flags & COND_CANON_INTS) != 0 && i > 0 {
         // in strict mode, we don't allow any redundant leading zeros
         return Err(ValidationErr(n, code));
     }

--- a/src/py/api.rs
+++ b/src/py/api.rs
@@ -7,7 +7,10 @@ use super::run_program::{
     __pyo3_get_function_deserialize_and_run_program2, __pyo3_get_function_run_chia_program,
     __pyo3_get_function_serialized_length,
 };
-use crate::run_program::STRICT_MODE;
+use crate::chia_dialect::{NO_NEG_DIV, NO_UNKNOWN_OPS};
+use crate::gen::flags::{COND_CANON_INTS, NO_UNKNOWN_CONDS};
+
+pub const MEMPOOL_MODE: u32 = NO_NEG_DIV | COND_CANON_INTS | NO_UNKNOWN_CONDS | NO_UNKNOWN_OPS;
 
 /// This module is a python module implemented in Rust.
 #[pymodule]
@@ -15,7 +18,11 @@ fn clvm_rs(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(deserialize_and_run_program2, m)?)?;
     m.add_function(wrap_pyfunction!(run_generator2, m)?)?;
     m.add_function(wrap_pyfunction!(run_chia_program, m)?)?;
-    m.add("STRICT_MODE", STRICT_MODE)?;
+    m.add("NO_NEG_DIV", NO_NEG_DIV)?;
+    m.add("COND_CANON_INTS", COND_CANON_INTS)?;
+    m.add("NO_UNKNOWN_CONDS", NO_UNKNOWN_CONDS)?;
+    m.add("NO_UNKNOWN_OPS", NO_UNKNOWN_OPS)?;
+    m.add("MEMPOOL_MODE", MEMPOOL_MODE)?;
     m.add_class::<LazyNode>()?;
     m.add_class::<PySpendBundleConditions>()?;
     m.add_class::<PySpend>()?;

--- a/src/py/run_generator.rs
+++ b/src/py/run_generator.rs
@@ -5,7 +5,7 @@ use crate::cost::Cost;
 use crate::gen::conditions::{parse_spends, Spend, SpendBundleConditions};
 use crate::gen::validation_error::{ErrorCode, ValidationErr};
 use crate::reduction::{EvalErr, Reduction};
-use crate::run_program::{run_program, STRICT_MODE};
+use crate::run_program::run_program;
 use crate::serialize::node_from_bytes;
 
 use pyo3::prelude::*;
@@ -144,10 +144,9 @@ pub fn run_generator2(
     flags: u32,
 ) -> PyResult<(Option<ErrorCode>, Option<PySpendBundleConditions>)> {
     let mut allocator = Allocator::new();
-    let strict: bool = (flags & STRICT_MODE) != 0;
     let program = node_from_bytes(&mut allocator, program)?;
     let args = node_from_bytes(&mut allocator, args)?;
-    let dialect = &ChiaDialect::new(strict);
+    let dialect = &ChiaDialect::new(flags);
 
     let r = py.allow_threads(
         || -> Result<(Option<ErrorCode>, Option<SpendBundleConditions>), EvalErr> {

--- a/src/py/run_program.rs
+++ b/src/py/run_program.rs
@@ -7,7 +7,7 @@ use crate::py::adapt_response::adapt_response_to_py;
 use crate::py::lazy_node::LazyNode;
 use crate::py::runtime_dialect::RuntimeDialect;
 use crate::reduction::Response;
-use crate::run_program::{run_program, STRICT_MODE};
+use crate::run_program::run_program;
 use crate::serialize::{node_from_bytes, serialized_length_from_bytes};
 
 use pyo3::prelude::*;
@@ -30,7 +30,7 @@ pub fn run_serialized_program(
         opcode_lookup_by_name,
         quote_kw.to_vec(),
         apply_kw.to_vec(),
-        (flags & STRICT_MODE) != 0,
+        flags,
     );
 
     Ok(py.allow_threads(|| run_program(allocator, &dialect, program, args, max_cost, None)))
@@ -81,7 +81,7 @@ pub fn run_chia_program(
     let r: Response = (|| -> PyResult<Response> {
         let program = node_from_bytes(&mut allocator, program)?;
         let args = node_from_bytes(&mut allocator, args)?;
-        let dialect = ChiaDialect::new((flags & STRICT_MODE) != 0);
+        let dialect = ChiaDialect::new(flags);
 
         Ok(py
             .allow_threads(|| run_program(&mut allocator, &dialect, program, args, max_cost, None)))

--- a/src/py/runtime_dialect.rs
+++ b/src/py/runtime_dialect.rs
@@ -1,4 +1,5 @@
 use crate::allocator::{Allocator, NodePtr};
+use crate::chia_dialect::NO_UNKNOWN_OPS;
 use crate::cost::Cost;
 use crate::dialect::Dialect;
 use crate::err_utils::err;
@@ -11,7 +12,7 @@ pub struct RuntimeDialect {
     f_lookup: FLookup,
     quote_kw: Vec<u8>,
     apply_kw: Vec<u8>,
-    strict: bool,
+    flags: u32,
 }
 
 impl RuntimeDialect {
@@ -19,13 +20,13 @@ impl RuntimeDialect {
         op_map: HashMap<String, Vec<u8>>,
         quote_kw: Vec<u8>,
         apply_kw: Vec<u8>,
-        strict: bool,
+        flags: u32,
     ) -> RuntimeDialect {
         RuntimeDialect {
             f_lookup: f_lookup_for_hashmap(op_map),
             quote_kw,
             apply_kw,
-            strict,
+            flags,
         }
     }
 }
@@ -44,7 +45,7 @@ impl Dialect for RuntimeDialect {
                 return f(allocator, argument_list, max_cost);
             }
         }
-        if self.strict {
+        if (self.flags & NO_UNKNOWN_OPS) != 0 {
             err(o, "unimplemented operator")
         } else {
             op_unknown(allocator, o, argument_list, max_cost)

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -7,8 +7,6 @@ use crate::reduction::{EvalErr, Reduction, Response};
 
 use crate::number::{ptr_from_number, Number};
 
-pub const STRICT_MODE: u32 = 1;
-
 // lowered from 46
 const QUOTE_COST: Cost = 20;
 // lowered from 138

--- a/src/wasm/api.rs
+++ b/src/wasm/api.rs
@@ -27,13 +27,12 @@ static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 pub fn run_clvm(program: &[u8], args: &[u8]) -> Vec<u8> {
     let max_cost: Cost = 1_000_000_000_000_000;
 
-    let strict: bool = false;
     let mut allocator = Allocator::new();
     let program = node_from_bytes(&mut allocator, program).unwrap();
     let args = node_from_bytes(&mut allocator, args).unwrap();
     let r = run_program(
         &mut allocator,
-        &ChiaDialect::new(strict),
+        &ChiaDialect::new(0),
         program,
         args,
         max_cost,

--- a/tests/run_gen.py
+++ b/tests/run_gen.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from clvm_rs import run_generator2, STRICT_MODE
+from clvm_rs import run_generator2
 from time import time
 from clvm_tools import binutils
 import sys

--- a/tests/test-generators.py
+++ b/tests/test-generators.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from run_gen import run_gen, print_spend_bundle_conditions
-from clvm_rs import STRICT_MODE
+from clvm_rs import MEMPOOL_MODE
 from time import time
 import sys
 import glob
@@ -31,7 +31,7 @@ for g in glob.glob('generators/*.clvm'):
     output = parse_output(result, error_code)
 
     start_time = time()
-    error_code2, result2 = run_gen(g, STRICT_MODE)
+    error_code2, result2 = run_gen(g, MEMPOOL_MODE)
     run_time2 = time() - start_time
     output2 = parse_output(result2, error_code2)
 
@@ -40,7 +40,7 @@ for g in glob.glob('generators/*.clvm'):
         if not "STRICT" in expected:
             expected2 = expected
             if not (result is None and result2 is None or result.cost == result2.cost):
-                print("cost when running in strict mode differs from non-strict!")
+                print("cost when running in mempool mode differs from normal mode!")
                 failed = 1
         else:
             expected, expected2 = expected.split("STRICT:\n", 1)


### PR DESCRIPTION
and rename it to mempool-mode. This is to allow enabling them independently, for scheduled soft forks