### PR TITLE
run_generator2 u16 error to match python

### DIFF
--- a/src/gen/validation_error.rs
+++ b/src/gen/validation_error.rs
@@ -76,8 +76,8 @@ pub fn check_nil(a: &Allocator, n: NodePtr) -> Result<(), ValidationErr> {
 }
 
 // from chia-blockchain/chia/util/errors.py
-impl From<ErrorCode> for u32 {
-    fn from(err: ErrorCode) -> u32 {
+impl From<ErrorCode> for u16 {
+    fn from(err: ErrorCode) -> u16 {
         match err {
             ErrorCode::NegativeAmount => 124,
             ErrorCode::InvalidPuzzleHash => 10,

--- a/wheel/src/run_generator.rs
+++ b/wheel/src/run_generator.rs
@@ -109,7 +109,7 @@ pub fn run_generator2(
     args: &[u8],
     max_cost: Cost,
     flags: u32,
-) -> PyResult<(Option<u32>, Option<PySpendBundleConditions>)> {
+) -> PyResult<(Option<u16>, Option<PySpendBundleConditions>)> {
     let mut allocator = Allocator::new();
     let program = node_from_bytes(&mut allocator, program)?;
     let args = node_from_bytes(&mut allocator, args)?;


### PR DESCRIPTION
I noticed `run_as_generator` returns a `uint16` error, but the underlying `run_generator2` function returns a `u32`. This pr updates the clvm_rs return type to match the python. I'm not really familiar with rust so hopefully this change makes sense.

```python
def run_as_generator(self, max_cost: int, flags: int, *args) -> Tuple[Optional[uint16], Optional[Any]]:
```
https://github.com/Chia-Network/chia-blockchain/blob/b8ada1ceb760eb83acddc964dfea69469d0feffc/chia/types/blockchain_format/program.py#L249
https://github.com/Chia-Network/clvm_rs/blob/b332a8088e590b4f6f48b96705f3500449599450/wheel/src/run_generator.rs#L112

Tests are failing locally, but I see the same error on a fresh clone so I assume it is unrelated?
```
error[E0308]: mismatched types
   --> src/test_ops.rs:835:30
    |
835 |       let funs = HashMap::from([
    |  ______________________________^
836 | |         ("i", op_if as Opf),
837 | |         ("c", op_cons as Opf),
838 | |         ("f", op_first as Opf),
...   |
866 | |         ("softfork", op_softfork as Opf),
867 | |     ]);
    | |_____^ expected struct `HashMap`, found array of 31 elements
    |
    = note: expected struct `HashMap<_, _, _>`
                found array `[(&str, for<'r> fn(&'r mut allocator::Allocator, i32, u64) -> Result<Reduction, EvalErr>); 31]`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `clvmr`
```