### PR TITLE
the chia_rs wheel depends on facilities from the clvm_rs wheel

### DIFF
--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [lib]
 name = "clvm_rs"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 path = "src/lib.rs"
 
 [dependencies]


### PR DESCRIPTION
Those need to be exported as a rust library in order to be imported in the chia_rs wheel