### PR TITLE
Make single argument raise return its only argument for ease of visual inspection (re quexington)

### DIFF
--- a/src/core_ops.rs
+++ b/src/core_ops.rs
@@ -60,7 +60,16 @@ pub fn op_listp(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response 
 
 pub fn op_raise(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     let args = Node::new(a, input);
-    args.err("clvm raise")
+    // Quexington requested single argument raise to return the single argument
+    // rather than the full list of arguments.  brun also used to behave this
+    // way... it does make sense to ensure that the full context of the exception
+    // is passed on rather than a more cryptic error in the case of more arguments
+    // though (IMO).
+    if args.rest().map(|r| r.nullp()).unwrap_or_else(|_| false) {
+        args.first()?.err("clvm raise")
+    } else {
+        args.err("clvm raise")
+    }
 }
 
 pub fn op_eq(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {

--- a/src/test_ops.rs
+++ b/src/test_ops.rs
@@ -7,7 +7,7 @@ use crate::more_ops::{
     op_point_add, op_pubkey_for_exp, op_sha256, op_softfork, op_strlen, op_substr, op_subtract,
 };
 use crate::number::{ptr_from_number, Number};
-use crate::reduction::{Reduction, Response};
+use crate::reduction::{Reduction, Response, EvalErr};
 use hex::FromHex;
 use num_traits::Num;
 use std::cmp::min;
@@ -1160,4 +1160,24 @@ fn test_ops() {
             expected_cost.trim().parse().unwrap(),
         );
     }
+}
+
+#[test]
+fn test_single_argument_raise() {
+    let mut allocator = Allocator::new();
+    let a1 = allocator.new_atom(&[65]).unwrap();
+    let args = allocator.new_pair(a1, allocator.null()).unwrap();
+    let result = op_raise(&mut allocator, args, 100000);
+    assert_eq!(result, Err(EvalErr(a1, "clvm raise".to_string())));
+}
+
+#[test]
+fn test_multi_argument_raise() {
+    let mut allocator = Allocator::new();
+    let a1 = allocator.new_atom(&[65]).unwrap();
+    let a2 = allocator.new_atom(&[66]).unwrap();
+    let mut args = allocator.new_pair(a2, allocator.null()).unwrap();
+    args = allocator.new_pair(a1, args).unwrap();
+    let result = op_raise(&mut allocator, args, 100000);
+    assert_eq!(result, Err(EvalErr(args, "clvm raise".to_string())));
 }

--- a/src/test_ops.rs
+++ b/src/test_ops.rs
@@ -7,7 +7,7 @@ use crate::more_ops::{
     op_point_add, op_pubkey_for_exp, op_sha256, op_softfork, op_strlen, op_substr, op_subtract,
 };
 use crate::number::{ptr_from_number, Number};
-use crate::reduction::{Reduction, Response, EvalErr};
+use crate::reduction::{EvalErr, Reduction, Response};
 use hex::FromHex;
 use num_traits::Num;
 use std::cmp::min;
@@ -1163,7 +1163,7 @@ fn test_ops() {
 }
 
 #[test]
-fn test_single_argument_raise() {
+fn test_single_argument_raise_atom() {
     let mut allocator = Allocator::new();
     let a1 = allocator.new_atom(&[65]).unwrap();
     let args = allocator.new_pair(a1, allocator.null()).unwrap();
@@ -1172,11 +1172,28 @@ fn test_single_argument_raise() {
 }
 
 #[test]
+fn test_single_argument_raise_pair() {
+    let mut allocator = Allocator::new();
+    let a1 = allocator.new_atom(&[65]).unwrap();
+    let a2 = allocator.new_atom(&[66]).unwrap();
+    // (a2)
+    let mut args = allocator.new_pair(a2, allocator.null()).unwrap();
+    // (a1 a2)
+    args = allocator.new_pair(a1, args).unwrap();
+    // ((a1 a2))
+    args = allocator.new_pair(args, allocator.null()).unwrap();
+    let result = op_raise(&mut allocator, args, 100000);
+    assert_eq!(result, Err(EvalErr(args, "clvm raise".to_string())));
+}
+
+#[test]
 fn test_multi_argument_raise() {
     let mut allocator = Allocator::new();
     let a1 = allocator.new_atom(&[65]).unwrap();
     let a2 = allocator.new_atom(&[66]).unwrap();
+    // (a1)
     let mut args = allocator.new_pair(a2, allocator.null()).unwrap();
+    // (a1 a2)
     args = allocator.new_pair(a1, args).unwrap();
     let result = op_raise(&mut allocator, args, 100000);
     assert_eq!(result, Err(EvalErr(args, "clvm raise".to_string())));


### PR DESCRIPTION
A request was made that when x is given a single argument, the single argument is returned, making the bubbled result in python easier to inspect visually.