### PR TITLE
add function to compute the tree-hash

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -36,3 +36,9 @@ name = "fuzz_deserialize"
 path = "fuzz_targets/deserialize.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_tree_hash"
+path = "fuzz_targets/tree_hash.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/deserialize.rs
+++ b/fuzz/fuzz_targets/deserialize.rs
@@ -1,12 +1,14 @@
 #![no_main]
-use libfuzzer_sys::fuzz_target;
-use clvmr::serialize::node_from_bytes;
 use clvmr::allocator::Allocator;
+use clvmr::serialize::node_from_bytes;
+use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     let mut allocator = Allocator::new();
     let _program = match node_from_bytes(&mut allocator, data) {
-        Err(_) => { return; },
+        Err(_) => {
+            return;
+        }
         Ok(r) => r,
     };
 });

--- a/fuzz/fuzz_targets/run_program.rs
+++ b/fuzz/fuzz_targets/run_program.rs
@@ -1,24 +1,35 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
-use clvmr::chia_dialect::ChiaDialect;
 use clvmr::allocator::Allocator;
-use clvmr::reduction::Reduction;
-use clvmr::serialize::node_from_bytes;
+use clvmr::chia_dialect::ChiaDialect;
 use clvmr::cost::Cost;
+use clvmr::reduction::Reduction;
 use clvmr::run_program::run_program;
+use clvmr::serialize::node_from_bytes;
 
 fuzz_target!(|data: &[u8]| {
     let mut allocator = Allocator::new();
     let program = match node_from_bytes(&mut allocator, data) {
-        Err(_) => { return; },
+        Err(_) => {
+            return;
+        }
         Ok(r) => r,
     };
     let args = allocator.null();
     let dialect = ChiaDialect::new(0);
 
-    let Reduction(_cost, _node) = match run_program(&mut allocator, &dialect, program, args, 12000000000 as Cost, None) {
-        Err(_) => { return; },
+    let Reduction(_cost, _node) = match run_program(
+        &mut allocator,
+        &dialect,
+        program,
+        args,
+        12000000000 as Cost,
+        None,
+    ) {
+        Err(_) => {
+            return;
+        }
         Ok(r) => r,
     };
 });

--- a/fuzz/fuzz_targets/serialized_length.rs
+++ b/fuzz/fuzz_targets/serialized_length.rs
@@ -1,10 +1,12 @@
 #![no_main]
-use libfuzzer_sys::fuzz_target;
 use clvmr::serialize::serialized_length_from_bytes;
+use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     let _len = match serialized_length_from_bytes(data) {
-        Err(_) => { return; },
+        Err(_) => {
+            return;
+        }
         Ok(r) => r,
     };
 });

--- a/fuzz/fuzz_targets/tree_hash.rs
+++ b/fuzz/fuzz_targets/tree_hash.rs
@@ -1,10 +1,9 @@
 #![no_main]
-use libfuzzer_sys::fuzz_target;
 use clvmr::serialize::tree_hash_from_stream;
+use libfuzzer_sys::fuzz_target;
 use std::io::Cursor;
 
 fuzz_target!(|data: &[u8]| {
-
     let mut cursor = Cursor::<&[u8]>::new(data);
     let _ = tree_hash_from_stream(&mut cursor);
 });

--- a/fuzz/fuzz_targets/tree_hash.rs
+++ b/fuzz/fuzz_targets/tree_hash.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use clvmr::serialize::tree_hash_from_stream;
+use std::io::Cursor;
+
+fuzz_target!(|data: &[u8]| {
+
+    let mut cursor = Cursor::<&[u8]>::new(data);
+    let _ = tree_hash_from_stream(&mut cursor);
+});

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -231,6 +231,171 @@ pub fn serialized_length_from_bytes(b: &[u8]) -> io::Result<u64> {
     Ok(f.position())
 }
 
+use crate::sha2::{Digest, Sha256};
+
+fn hash_atom(buf: &[u8]) -> [u8; 32] {
+    let mut ctx = Sha256::new();
+    ctx.update(&[1_u8]);
+    ctx.update(buf);
+    ctx.finalize().into()
+}
+
+fn hash_pair(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
+    let mut ctx = Sha256::new();
+    ctx.update(&[2_u8]);
+    ctx.update(left);
+    ctx.update(right);
+    ctx.finalize().into()
+}
+
+// computes the tree-hash of a CLVM structure in serialized form
+pub fn tree_hash_from_stream(f: &mut Cursor<&[u8]>) -> io::Result<[u8; 32]> {
+    let mut values: Vec<[u8; 32]> = Vec::new();
+    let mut ops = vec![ParseOp::SExp];
+
+    let mut b = [0; 1];
+    loop {
+        let op = ops.pop();
+        if op.is_none() {
+            break;
+        }
+        match op.unwrap() {
+            ParseOp::SExp => {
+                f.read_exact(&mut b)?;
+                if b[0] == CONS_BOX_MARKER {
+                    ops.push(ParseOp::Cons);
+                    ops.push(ParseOp::SExp);
+                    ops.push(ParseOp::SExp);
+                } else if b[0] == 0x80 {
+                    values.push(hash_atom(&[]));
+                } else if b[0] <= MAX_SINGLE_BYTE {
+                    values.push(hash_atom(&b));
+                } else {
+                    let blob_size = decode_size(f, b[0])?;
+                    let blob = &f.get_ref()[f.position() as usize..];
+                    if (blob.len() as u64) < blob_size {
+                        return Err(bad_encoding());
+                    }
+                    f.set_position(f.position() + blob_size);
+                    values.push(hash_atom(&blob[..blob_size as usize]));
+                }
+            }
+            ParseOp::Cons => {
+                // cons
+                let v2 = values.pop();
+                let v1 = values.pop();
+                values.push(hash_pair(&v1.unwrap(), &v2.unwrap()));
+            }
+        }
+    }
+    Ok(values.pop().unwrap())
+}
+
+#[test]
+fn test_tree_hash_max_single_byte() {
+    let mut ctx = Sha256::new();
+    ctx.update(&[1_u8]);
+    ctx.update(&[0x7f_u8]);
+    let mut cursor = Cursor::<&[u8]>::new(&[0x7f_u8]);
+    assert_eq!(
+        tree_hash_from_stream(&mut cursor).unwrap(),
+        ctx.finalize().as_slice()
+    );
+}
+
+#[test]
+fn test_tree_hash_one() {
+    let mut ctx = Sha256::new();
+    ctx.update(&[1_u8]);
+    ctx.update(&[1_u8]);
+    let mut cursor = Cursor::<&[u8]>::new(&[1_u8]);
+    assert_eq!(
+        tree_hash_from_stream(&mut cursor).unwrap(),
+        ctx.finalize().as_slice()
+    );
+}
+
+#[test]
+fn test_tree_hash_zero() {
+    let mut ctx = Sha256::new();
+    ctx.update(&[1_u8]);
+    ctx.update(&[0_u8]);
+    let mut cursor = Cursor::<&[u8]>::new(&[0_u8]);
+    assert_eq!(
+        tree_hash_from_stream(&mut cursor).unwrap(),
+        ctx.finalize().as_slice()
+    );
+}
+
+#[test]
+fn test_tree_hash_nil() {
+    let mut ctx = Sha256::new();
+    ctx.update(&[1_u8]);
+    let mut cursor = Cursor::<&[u8]>::new(&[0x80_u8]);
+    assert_eq!(
+        tree_hash_from_stream(&mut cursor).unwrap(),
+        ctx.finalize().as_slice()
+    );
+}
+
+#[test]
+fn test_tree_hash_overlong() {
+    let mut cursor = Cursor::<&[u8]>::new(&[0x8f, 0xff]);
+    let e = tree_hash_from_stream(&mut cursor).unwrap_err();
+    assert_eq!(e.kind(), bad_encoding().kind());
+
+    let mut cursor = Cursor::<&[u8]>::new(&[0b11001111, 0xff]);
+    let e = tree_hash_from_stream(&mut cursor).unwrap_err();
+    assert_eq!(e.kind(), bad_encoding().kind());
+
+    let mut cursor = Cursor::<&[u8]>::new(&[0b11001111, 0xff, 0, 0]);
+    let e = tree_hash_from_stream(&mut cursor).unwrap_err();
+    assert_eq!(e.kind(), bad_encoding().kind());
+}
+
+#[cfg(test)]
+use hex::FromHex;
+
+// these test cases were produced by:
+
+// from chia.types.blockchain_format.program import Program
+// a = Program.to(...)
+// print(bytes(a).hex())
+// print(a.get_tree_hash().hex())
+
+#[test]
+fn test_tree_hash_list() {
+    // this is the list (1 (2 (3 (4 (5 ())))))
+    let buf = Vec::from_hex("ff01ff02ff03ff04ff0580").unwrap();
+    let mut cursor = Cursor::<&[u8]>::new(&buf);
+    assert_eq!(
+        tree_hash_from_stream(&mut cursor).unwrap().to_vec(),
+        Vec::from_hex("123190dddde51acfc61f48429a879a7b905d1726a52991f7d63349863d06b1b6").unwrap()
+    );
+}
+
+#[test]
+fn test_tree_hash_tree() {
+    // this is the tree ((1, 2), (3, 4))
+    let buf = Vec::from_hex("ffff0102ff0304").unwrap();
+    let mut cursor = Cursor::<&[u8]>::new(&buf);
+    assert_eq!(
+        tree_hash_from_stream(&mut cursor).unwrap().to_vec(),
+        Vec::from_hex("2824018d148bc6aed0847e2c86aaa8a5407b916169f15b12cea31fa932fc4c8d").unwrap()
+    );
+}
+
+#[test]
+fn test_tree_hash_tree_large_atom() {
+    // this is the tree ((1, 2), (3, b"foobar"))
+    let buf = Vec::from_hex("ffff0102ff0386666f6f626172").unwrap();
+    let mut cursor = Cursor::<&[u8]>::new(&buf);
+    assert_eq!(
+        tree_hash_from_stream(&mut cursor).unwrap().to_vec(),
+        Vec::from_hex("b28d5b401bd02b65b7ed93de8e916cfc488738323e568bcca7e032c3a97a12e4").unwrap()
+    );
+}
+
 #[test]
 fn test_serialized_length_from_bytes() {
     assert_eq!(


### PR DESCRIPTION
from a CLVM structure in serialized form

The second commit is unrelated. it's just running `cargo fmt` on the fuzz targets.