### PR TITLE
run_program simplifications

### DIFF
--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -62,15 +62,13 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
 }
 
 fn augment_cost_errors(r: Result<Cost, EvalErr>, max_cost: NodePtr) -> Result<Cost, EvalErr> {
-    if r.is_ok() {
-        return r;
-    }
-    let e = r.unwrap_err();
-    if &e.1 != "cost exceeded" {
-        Err(e)
-    } else {
-        Err(EvalErr(max_cost, e.1))
-    }
+    r.map_err(|e| {
+        if &e.1 != "cost exceeded" {
+            e
+        } else {
+            EvalErr(max_cost, e.1)
+        }
+    })
 }
 
 impl<'a, D: Dialect> RunProgramContext<'a, D> {

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -164,7 +164,7 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
             SExp::Pair(operator_node, operand_list) => (operator_node, operand_list),
         };
 
-        let op_atom = match self.allocator.sexp(op_node) {
+        match self.allocator.sexp(op_node) {
             SExp::Pair(new_operator, must_be_nil) => {
                 if let SExp::Atom(_) = self.allocator.sexp(new_operator) {
                     if Node::new(self.allocator, must_be_nil).nullp() {
@@ -177,10 +177,8 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
                 return Node::new(self.allocator, program)
                     .err("in ((X)...) syntax X must be lone atom");
             }
-            SExp::Atom(op_atom) => op_atom,
-        };
-
-        self.eval_op_atom(&op_atom, op_node, op_list, args)
+            SExp::Atom(op_atom) => self.eval_op_atom(&op_atom, op_node, op_list, args),
+        }
     }
 
     fn swap_eval_op(&mut self) -> Result<Cost, EvalErr> {

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -41,6 +41,16 @@ struct RunProgramContext<'a, D> {
     val_stack_limit: usize,
 }
 
+fn augment_cost_errors(r: Result<Cost, EvalErr>, max_cost: NodePtr) -> Result<Cost, EvalErr> {
+    r.map_err(|e| {
+        if &e.1 != "cost exceeded" {
+            e
+        } else {
+            EvalErr(max_cost, e.1)
+        }
+    })
+}
+
 impl<'a, D: Dialect> RunProgramContext<'a, D> {
     pub fn pop(&mut self) -> Result<NodePtr, EvalErr> {
         let v: Option<NodePtr> = self.val_stack.pop();
@@ -59,19 +69,7 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
         self.val_stack.push(node);
         Ok(())
     }
-}
 
-fn augment_cost_errors(r: Result<Cost, EvalErr>, max_cost: NodePtr) -> Result<Cost, EvalErr> {
-    r.map_err(|e| {
-        if &e.1 != "cost exceeded" {
-            e
-        } else {
-            EvalErr(max_cost, e.1)
-        }
-    })
-}
-
-impl<'a, D: Dialect> RunProgramContext<'a, D> {
     fn new(allocator: &'a mut Allocator, dialect: &'a D, pre_eval: Option<PreEval>) -> Self {
         RunProgramContext {
             allocator,
@@ -92,9 +90,7 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
         self.push(p)?;
         Ok(0)
     }
-}
 
-impl<'a, D: Dialect> RunProgramContext<'a, D> {
     fn eval_op_atom(
         &mut self,
         op_buf: &AtomBuf,

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -145,13 +145,11 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
     }
 
     fn eval_pair(&mut self, program: NodePtr, args: NodePtr) -> Result<Cost, EvalErr> {
-        let post_eval = match self.pre_eval {
-            None => None,
-            Some(ref pre_eval) => pre_eval(self.allocator, program, args)?,
-        };
-        if let Some(post_eval) = post_eval {
-            self.posteval_stack.push(post_eval);
-            self.op_stack.push(Operation::PostEval);
+        if let Some(pre_eval) = &self.pre_eval {
+            if let Some(post_eval) = pre_eval(self.allocator, program, args)? {
+                self.posteval_stack.push(post_eval);
+                self.op_stack.push(Operation::PostEval);
+            }
         };
 
         // put a bunch of ops on op_stack


### PR DESCRIPTION
some minor simplifications, saving lines of code and indentation levels.

These patches are probably best reviewed one at a time. They are all independent.