### PR TITLE
revert front-load patches. add option to limit stack size

### DIFF
--- a/src/chia_dialect.rs
+++ b/src/chia_dialect.rs
@@ -22,6 +22,9 @@ pub const NO_UNKNOWN_OPS: u32 = 0x0002;
 // the number of pairs
 pub const LIMIT_HEAP: u32 = 0x0004;
 
+// When set, enforce a stack size limit for CLVM programs
+pub const LIMIT_STACK: u32 = 0x0008;
+
 pub struct ChiaDialect {
     flags: u32,
 }
@@ -108,8 +111,8 @@ impl Dialect for ChiaDialect {
         &[2]
     }
 
-    fn val_stack_limit(&self) -> usize {
-        if (self.flags & LIMIT_HEAP) != 0 {
+    fn stack_limit(&self) -> usize {
+        if (self.flags & LIMIT_STACK) != 0 {
             10000000
         } else {
             usize::MAX

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -7,5 +7,5 @@ pub trait Dialect {
     fn apply_kw(&self) -> &[u8];
     fn op(&self, allocator: &mut Allocator, op: NodePtr, args: NodePtr, max_cost: Cost)
         -> Response;
-    fn val_stack_limit(&self) -> usize;
+    fn stack_limit(&self) -> usize;
 }

--- a/src/runtime_dialect.rs
+++ b/src/runtime_dialect.rs
@@ -60,7 +60,7 @@ impl Dialect for RuntimeDialect {
         &self.apply_kw
     }
 
-    fn val_stack_limit(&self) -> usize {
+    fn stack_limit(&self) -> usize {
         usize::MAX
     }
 }

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -6,9 +6,9 @@ use super::run_program::{
     __pyo3_get_function_deserialize_and_run_program2, __pyo3_get_function_run_chia_program,
     __pyo3_get_function_serialized_length,
 };
-use clvmr::chia_dialect::{LIMIT_HEAP, NO_NEG_DIV, NO_UNKNOWN_OPS};
+use clvmr::chia_dialect::{LIMIT_HEAP, NO_NEG_DIV, NO_UNKNOWN_OPS, LIMIT_STACK};
 
-pub const MEMPOOL_MODE: u32 = NO_NEG_DIV | NO_UNKNOWN_OPS | LIMIT_HEAP;
+pub const MEMPOOL_MODE: u32 = NO_NEG_DIV | NO_UNKNOWN_OPS | LIMIT_HEAP | LIMIT_STACK;
 
 #[pymodule]
 fn clvm_rs(_py: Python, m: &PyModule) -> PyResult<()> {
@@ -17,6 +17,7 @@ fn clvm_rs(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add("NO_NEG_DIV", NO_NEG_DIV)?;
     m.add("NO_UNKNOWN_OPS", NO_UNKNOWN_OPS)?;
     m.add("LIMIT_HEAP", LIMIT_HEAP)?;
+    m.add("LIMIT_STACK", LIMIT_STACK)?;
     m.add("MEMPOOL_MODE", MEMPOOL_MODE)?;
     m.add_class::<LazyNode>()?;
 


### PR DESCRIPTION
This reverts two patches that attempted to front-load the cost of evaluating arguments pushed onto the stack. They were both broken. The failures were detected by one of the fuzzers, but we don't run those on CI (yet, there's a separate PR for that).

In addition to reverting the two bad patches, a third commit splits outs parts if the `LIMIT_HEAP` flag into a `LIMIT_STACK`. This way the stack and heap limits can be employed independently.