### PR TITLE
build feature to instrument clvm program

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -239,5 +239,7 @@ jobs:
         with:
             toolchain: stable
             components: rustfmt, clippy
-      - name: cargo test
+      - name: cargo test (default)
         run: cargo test && cargo test --release
+      - name: cargo test (counters)
+        run: cargo test --features=counters && cargo test --features=counters --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ readme = "README.md"
 name = "clvmr"
 crate-type = ["rlib"]
 
+[features]
+# when enabling the "counters" features, the CLVM interpreter is instrumented to
+# collect counters about the programs it executes
+counters = []
+
 [profile.release]
 lto = true
 

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -216,6 +216,21 @@ impl Allocator {
     pub fn one(&self) -> NodePtr {
         -2
     }
+
+    #[cfg(feature = "counters")]
+    pub fn atom_count(&self) -> usize {
+        self.atom_vec.len()
+    }
+
+    #[cfg(feature = "counters")]
+    pub fn pair_count(&self) -> usize {
+        self.pair_vec.len()
+    }
+
+    #[cfg(feature = "counters")]
+    pub fn heap_size(&self) -> usize {
+        self.u8_vec.len()
+    }
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,16 @@ pub mod serde;
 pub mod sha2;
 pub mod traverse_path;
 
+pub use allocator::Allocator;
+pub use chia_dialect::ChiaDialect;
+pub use run_program::run_program;
+
+#[cfg(feature = "counters")]
+pub use run_program::run_program_with_counters;
+
+#[cfg(feature = "counters")]
+pub use run_program::Counters;
+
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
This patch adds a new build feature (`counters`), disabled by default. When enabled, a new function to run a clvm program is exported, `run_program_with_counters()`, which returns a `Counters` object including the max stack sizes used by the program as well as the heap size and atom and pair allocations.

This is in support of analyzing and gathering statistics for programs.