### PR TITLE
bump rust edition to 2021 and fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clvmr"
 version = "0.2.1"
 authors = ["Richard Kiss <him@richardkiss.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "Implementation of `clvm` for Chia Network's cryptocurrency"
 homepage = "https://github.com/Chia-Network/clvm_rs/"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "clvm_rs-fuzz"
 version = "1.0.0"
 authors = ["Arvid Norberg <arvid@chia.net>"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/src/f_table.rs
+++ b/src/f_table.rs
@@ -64,7 +64,7 @@ pub fn f_lookup_for_hashmap(opcode_lookup_by_name: HashMap<String, Vec<u8>>) -> 
         if idx.len() == 1 {
             let index = idx[0];
             let op = opcode_by_name(name);
-            assert!(op.is_some(), "can't find native operator {:?}", name);
+            assert!(op.is_some(), "can't find native operator {name}");
             f_lookup[index as usize] = op;
         }
     }

--- a/src/more_ops.rs
+++ b/src/more_ops.rs
@@ -892,7 +892,7 @@ pub fn op_point_add(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Respon
         }
         if !is_ok {
             let blob: String = hex::encode(node_to_bytes(&arg).unwrap());
-            let msg = format!("point_add expects blob, got {}: Length of bytes object not equal to G1Element::SIZE", blob);
+            let msg = format!("point_add expects blob, got {blob}: Length of bytes object not equal to G1Element::SIZE");
             return args.err(&msg);
         }
     }

--- a/src/op_utils.rs
+++ b/src/op_utils.rs
@@ -69,7 +69,7 @@ fn test_arg_count() {
 pub fn int_atom<'a>(args: &'a Node, op_name: &str) -> Result<&'a [u8], EvalErr> {
     match args.atom() {
         Some(a) => Ok(a),
-        _ => args.err(&format!("{} requires int args", op_name)),
+        _ => args.err(&format!("{op_name} requires int args")),
     }
 }
 
@@ -77,7 +77,7 @@ pub fn int_atom<'a>(args: &'a Node, op_name: &str) -> Result<&'a [u8], EvalErr> 
 pub fn atom<'a>(args: &'a Node, op_name: &str) -> Result<&'a [u8], EvalErr> {
     match args.atom() {
         Some(a) => Ok(a),
-        _ => args.err(&format!("{} on list", op_name)),
+        _ => args.err(&format!("{op_name} on list")),
     }
 }
 
@@ -212,14 +212,13 @@ pub fn i32_atom(args: &Node, op_name: &str) -> Result<i32, EvalErr> {
     let buf = match args.atom() {
         Some(a) => a,
         _ => {
-            return args.err(&format!("{} requires int32 args", op_name));
+            return args.err(&format!("{op_name} requires int32 args"));
         }
     };
     match i32_from_u8(buf) {
         Some(v) => Ok(v),
         _ => args.err(&format!(
-            "{} requires int32 args (with no leading zeros)",
-            op_name
+            "{op_name} requires int32 args (with no leading zeros)"
         )),
     }
 }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clvm_wasm"
 version = "0.2.1"
 authors = ["Richard Kiss <him@richardkiss.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "Implementation of `clvm` for Chia Network's cryptocurrency"
 homepage = "https://github.com/Chia-Network/clvm_rs/"

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -2,7 +2,7 @@
 name = "clvm_rs"
 version = "0.2.1"
 authors = ["Richard Kiss <him@richardkiss.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "Implementation of `clvm` for Chia Network's cryptocurrency"
 homepage = "https://github.com/Chia-Network/clvm_rs/"


### PR DESCRIPTION
the support for "string interpolation" is new in rust 2021 (at least in some places). However, clippy warns about it regardless of whether you're using rust 2018. So, this fixes the clippy issues, and also bumps the rust version in order for it to be supported.