### PR TITLE
move the mempool-mode flag into the rust crate

### DIFF
--- a/src/chia_dialect.rs
+++ b/src/chia_dialect.rs
@@ -25,6 +25,10 @@ pub const LIMIT_HEAP: u32 = 0x0004;
 // When set, enforce a stack size limit for CLVM programs
 pub const LIMIT_STACK: u32 = 0x0008;
 
+// The default mode when running grnerators in mempool-mode (i.e. the stricter
+// mode)
+pub const MEMPOOL_MODE: u32 = NO_NEG_DIV | NO_UNKNOWN_OPS | LIMIT_HEAP | LIMIT_STACK;
+
 pub struct ChiaDialect {
     flags: u32,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ pub use allocator::Allocator;
 pub use chia_dialect::ChiaDialect;
 pub use run_program::run_program;
 
+pub use chia_dialect::{LIMIT_HEAP, LIMIT_STACK, MEMPOOL_MODE, NO_NEG_DIV, NO_UNKNOWN_OPS};
+
 #[cfg(feature = "counters")]
 pub use run_program::run_program_with_counters;
 

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -6,9 +6,7 @@ use super::run_program::{
     __pyo3_get_function_deserialize_and_run_program2, __pyo3_get_function_run_chia_program,
     __pyo3_get_function_serialized_length,
 };
-use clvmr::chia_dialect::{LIMIT_HEAP, NO_NEG_DIV, NO_UNKNOWN_OPS, LIMIT_STACK};
-
-pub const MEMPOOL_MODE: u32 = NO_NEG_DIV | NO_UNKNOWN_OPS | LIMIT_HEAP | LIMIT_STACK;
+use clvmr::{LIMIT_HEAP, NO_NEG_DIV, NO_UNKNOWN_OPS, LIMIT_STACK, MEMPOOL_MODE};
 
 #[pymodule]
 fn clvm_rs(_py: Python, m: &PyModule) -> PyResult<()> {


### PR DESCRIPTION
instead of defining it in the python interface. This enables code deduplication when the same flag is exported from the chia_rs wheel