### PR TITLE
add a build feature to enable pre-eval and post-eval functionality

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -239,7 +239,12 @@ jobs:
         with:
             toolchain: stable
             components: rustfmt, clippy
+
       - name: cargo test (default)
         run: cargo test && cargo test --release
+
       - name: cargo test (counters)
         run: cargo test --features=counters && cargo test --features=counters --release
+
+      - name: cargo test (pre-eval)
+        run: cargo test --features=pre-eval && cargo test --features=pre-eval --release

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -248,3 +248,6 @@ jobs:
 
       - name: cargo test (pre-eval)
         run: cargo test --features=pre-eval && cargo test --features=pre-eval --release
+
+      - name: cargo test (pre-eval and counters)
+        run: cargo test --features=pre-eval,counters && cargo test --features=pre-eval,counters --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,10 @@ crate-type = ["rlib"]
 # collect counters about the programs it executes
 counters = []
 
+# when enabled, pre-eval and post-eval callbacks are enabled. This is useful for
+# debugging and tracing of programs.
+pre-eval = []
+
 [profile.release]
 lto = true
 

--- a/fuzz/fuzz_targets/run_program.rs
+++ b/fuzz/fuzz_targets/run_program.rs
@@ -25,7 +25,6 @@ fuzz_target!(|data: &[u8]| {
         program,
         args,
         12000000000 as Cost,
-        None,
     ) {
         Err(_) => {
             return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ pub use run_program::run_program;
 #[cfg(feature = "counters")]
 pub use run_program::run_program_with_counters;
 
+#[cfg(feature = "pre-eval")]
+pub use run_program::run_program_with_pre_eval;
+
 #[cfg(feature = "counters")]
 pub use run_program::Counters;
 

--- a/src/test_ops.rs
+++ b/src/test_ops.rs
@@ -1,8 +1,4 @@
-use std::cell::RefCell;
-use std::rc::Rc; // Allows move closures to tear off a reference and move it. // Allows interior mutability inside Fn traits.
-
 use crate::allocator::{Allocator, NodePtr, SExp};
-use crate::chia_dialect::{ChiaDialect, NO_NEG_DIV, NO_UNKNOWN_OPS};
 use crate::core_ops::{op_cons, op_eq, op_first, op_if, op_listp, op_raise, op_rest};
 use crate::cost::Cost;
 use crate::more_ops::{
@@ -12,11 +8,11 @@ use crate::more_ops::{
 };
 use crate::number::{ptr_from_number, Number};
 use crate::reduction::{EvalErr, Reduction, Response};
-use crate::run_program::run_program;
+
 use hex::FromHex;
 use num_traits::Num;
 use std::cmp::min;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 // the format of these test cases is the following. expected-cost is optional
 // and is not relevant for FAIL cases
@@ -1204,14 +1200,17 @@ fn test_multi_argument_raise() {
     assert_eq!(result, Err(EvalErr(args, "clvm raise".to_string())));
 }
 
+#[cfg(feature = "pre-eval")]
 const COST_LIMIT: u64 = 1000000000;
 
+#[cfg(feature = "pre-eval")]
 struct EvalFTracker {
     pub prog: NodePtr,
     pub args: NodePtr,
     pub outcome: Option<NodePtr>,
 }
 
+#[cfg(feature = "pre-eval")]
 fn equal_sexp(allocator: &Allocator, s1: NodePtr, s2: NodePtr) -> bool {
     match (allocator.sexp(s1), allocator.sexp(s2)) {
         (SExp::Pair(s1a, s1b), SExp::Pair(s2a, s2b)) => {
@@ -1226,7 +1225,22 @@ fn equal_sexp(allocator: &Allocator, s1: NodePtr, s2: NodePtr) -> bool {
     }
 }
 
+#[cfg(feature = "pre-eval")]
+use crate::chia_dialect::{ChiaDialect, NO_NEG_DIV, NO_UNKNOWN_OPS};
+#[cfg(feature = "pre-eval")]
+use crate::run_program::run_program;
+#[cfg(feature = "pre-eval")]
+use std::cell::RefCell;
+#[cfg(feature = "pre-eval")]
+use std::collections::HashSet;
+
+// Allows move closures to tear off a reference and move it. // Allows interior
+// mutability inside Fn traits.
+#[cfg(feature = "pre-eval")]
+use std::rc::Rc;
+
 // Ensure pre_eval_f and post_eval_f are working as expected.
+#[cfg(feature = "pre-eval")]
 #[test]
 fn test_pre_eval_and_post_eval() {
     let mut allocator = Allocator::new();

--- a/src/test_ops.rs
+++ b/src/test_ops.rs
@@ -1228,7 +1228,7 @@ fn equal_sexp(allocator: &Allocator, s1: NodePtr, s2: NodePtr) -> bool {
 #[cfg(feature = "pre-eval")]
 use crate::chia_dialect::{ChiaDialect, NO_NEG_DIV, NO_UNKNOWN_OPS};
 #[cfg(feature = "pre-eval")]
-use crate::run_program::run_program;
+use crate::run_program::run_program_with_pre_eval;
 #[cfg(feature = "pre-eval")]
 use std::cell::RefCell;
 #[cfg(feature = "pre-eval")]
@@ -1309,7 +1309,7 @@ fn test_pre_eval_and_post_eval() {
     });
 
     let allocator_null = allocator.null();
-    let result = run_program(
+    let result = run_program_with_pre_eval(
         &mut allocator,
         &ChiaDialect::new(NO_NEG_DIV | NO_UNKNOWN_OPS),
         program,

--- a/wasm/src/api.rs
+++ b/wasm/src/api.rs
@@ -52,7 +52,6 @@ pub fn run_clvm(program: &[u8], args: &[u8]) -> Vec<u8> {
         program,
         args,
         max_cost,
-        None,
     );
     match r {
         Ok(reduction) => node_to_bytes(&Node::new(&allocator, reduction.1)).unwrap(),
@@ -78,7 +77,6 @@ pub fn run_chia_program(
         program,
         args,
         max_cost,
-        None,
     );
     match r {
         Ok(reduction) => {

--- a/wheel/Cargo.lock
+++ b/wheel/Cargo.lock
@@ -68,7 +68,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clvm_rs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clvmr",
  "pyo3",
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bls12_381",
  "hex",

--- a/wheel/src/run_program.rs
+++ b/wheel/src/run_program.rs
@@ -33,7 +33,7 @@ pub fn run_serialized_program(
         flags,
     );
 
-    Ok(py.allow_threads(|| run_program(allocator, &dialect, program, args, max_cost, None)))
+    Ok(py.allow_threads(|| run_program(allocator, &dialect, program, args, max_cost)))
 }
 
 #[pyfunction]
@@ -92,7 +92,7 @@ pub fn run_chia_program(
         let dialect = ChiaDialect::new(flags);
 
         Ok(py
-            .allow_threads(|| run_program(&mut allocator, &dialect, program, args, max_cost, None)))
+            .allow_threads(|| run_program(&mut allocator, &dialect, program, args, max_cost)))
     })()?;
     adapt_response_to_py(py, allocator, r)
 }


### PR DESCRIPTION
the pre- and post-eval functionality is not used in block validation, but *is* used during compilation and debugging.
This allows block validation to not include this logic.

This change would (probably) require `clvm_tools_rs` to depend on this with the `pre-eval` feature enabled.

Note that the wheel in `clvm_rs` does not support the pre-eval function, so it doesn't need it enabled.