### PR TITLE
remove NO_NEG_DIV flag and hard-code it in the division operator

### DIFF
--- a/src/chia_dialect.rs
+++ b/src/chia_dialect.rs
@@ -4,15 +4,11 @@ use crate::cost::Cost;
 use crate::dialect::Dialect;
 use crate::err_utils::err;
 use crate::more_ops::{
-    op_add, op_all, op_any, op_ash, op_concat, op_div, op_div_deprecated, op_divmod, op_gr,
-    op_gr_bytes, op_logand, op_logior, op_lognot, op_logxor, op_lsh, op_multiply, op_not,
-    op_point_add, op_pubkey_for_exp, op_sha256, op_softfork, op_strlen, op_substr, op_subtract,
-    op_unknown,
+    op_add, op_all, op_any, op_ash, op_concat, op_div, op_divmod, op_gr, op_gr_bytes, op_logand,
+    op_logior, op_lognot, op_logxor, op_lsh, op_multiply, op_not, op_point_add, op_pubkey_for_exp,
+    op_sha256, op_softfork, op_strlen, op_substr, op_subtract, op_unknown,
 };
 use crate::reduction::Response;
-
-// division with negative numbers are disallowed
-pub const NO_NEG_DIV: u32 = 0x0001;
 
 // unknown operators are disallowed
 // (otherwise they are no-ops with well defined cost)
@@ -27,7 +23,7 @@ pub const LIMIT_STACK: u32 = 0x0008;
 
 // The default mode when running grnerators in mempool-mode (i.e. the stricter
 // mode)
-pub const MEMPOOL_MODE: u32 = NO_NEG_DIV | NO_UNKNOWN_OPS | LIMIT_HEAP | LIMIT_STACK;
+pub const MEMPOOL_MODE: u32 = NO_UNKNOWN_OPS | LIMIT_HEAP | LIMIT_STACK;
 
 pub struct ChiaDialect {
     flags: u32,
@@ -72,13 +68,7 @@ impl Dialect for ChiaDialect {
             16 => op_add,
             17 => op_subtract,
             18 => op_multiply,
-            19 => {
-                if (self.flags & NO_NEG_DIV) != 0 {
-                    op_div_deprecated
-                } else {
-                    op_div
-                }
-            }
+            19 => op_div,
             20 => op_divmod,
             21 => op_gr,
             22 => op_ash,

--- a/src/f_table.rs
+++ b/src/f_table.rs
@@ -4,9 +4,9 @@ use crate::allocator::{Allocator, NodePtr};
 use crate::core_ops::{op_cons, op_eq, op_first, op_if, op_listp, op_raise, op_rest};
 use crate::cost::Cost;
 use crate::more_ops::{
-    op_add, op_all, op_any, op_ash, op_concat, op_div, op_div_deprecated, op_divmod, op_gr,
-    op_gr_bytes, op_logand, op_logior, op_lognot, op_logxor, op_lsh, op_multiply, op_not,
-    op_point_add, op_pubkey_for_exp, op_sha256, op_softfork, op_strlen, op_substr, op_subtract,
+    op_add, op_all, op_any, op_ash, op_concat, op_div, op_divmod, op_gr, op_gr_bytes, op_logand,
+    op_logior, op_lognot, op_logxor, op_lsh, op_multiply, op_not, op_point_add, op_pubkey_for_exp,
+    op_sha256, op_softfork, op_strlen, op_substr, op_subtract,
 };
 use crate::reduction::Response;
 
@@ -15,7 +15,7 @@ type OpFn = fn(&mut Allocator, NodePtr, Cost) -> Response;
 pub type FLookup = [Option<OpFn>; 256];
 
 pub fn opcode_by_name(name: &str) -> Option<OpFn> {
-    let opcode_lookup: [(OpFn, &str); 31] = [
+    let opcode_lookup: [(OpFn, &str); 30] = [
         (op_if, "op_if"),
         (op_cons, "op_cons"),
         (op_first, "op_first"),
@@ -46,7 +46,6 @@ pub fn opcode_by_name(name: &str) -> Option<OpFn> {
         (op_all, "op_all"),
         (op_softfork, "op_softfork"),
         (op_div, "op_div"),
-        (op_div_deprecated, "op_div_deprecated"),
     ];
     let name: &[u8] = name.as_ref();
     for (f, op) in opcode_lookup.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub use allocator::Allocator;
 pub use chia_dialect::ChiaDialect;
 pub use run_program::run_program;
 
-pub use chia_dialect::{LIMIT_HEAP, LIMIT_STACK, MEMPOOL_MODE, NO_NEG_DIV, NO_UNKNOWN_OPS};
+pub use chia_dialect::{LIMIT_HEAP, LIMIT_STACK, MEMPOOL_MODE, NO_UNKNOWN_OPS};
 
 #[cfg(feature = "counters")]
 pub use run_program::run_program_with_counters;

--- a/src/more_ops.rs
+++ b/src/more_ops.rs
@@ -423,14 +423,14 @@ pub fn op_multiply(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Respons
     Ok(malloc_cost(a, cost, total))
 }
 
-pub fn op_div_impl(a: &mut Allocator, input: NodePtr, mempool: bool) -> Response {
+pub fn op_div(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     let args = Node::new(a, input);
     let (a0, l0, a1, l1) = two_ints(&args, "/")?;
     let cost = DIV_BASE_COST + ((l0 + l1) as Cost) * DIV_COST_PER_BYTE;
     if a1.sign() == Sign::NoSign {
         args.first()?.err("div with 0")
     } else {
-        if mempool && (a0.sign() == Sign::Minus || a1.sign() == Sign::Minus) {
+        if a0.sign() == Sign::Minus || a1.sign() == Sign::Minus {
             return args.err("div operator with negative operands is deprecated");
         }
         let (mut q, r) = a0.div_mod_floor(&a1);
@@ -443,14 +443,6 @@ pub fn op_div_impl(a: &mut Allocator, input: NodePtr, mempool: bool) -> Response
         let q1 = ptr_from_number(a, &q)?;
         Ok(malloc_cost(a, cost, q1))
     }
-}
-
-pub fn op_div(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
-    op_div_impl(a, input, false)
-}
-
-pub fn op_div_deprecated(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
-    op_div_impl(a, input, true)
 }
 
 pub fn op_divmod(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {

--- a/wasm/src/api.rs
+++ b/wasm/src/api.rs
@@ -5,7 +5,6 @@ use js_sys::{Array};
 use crate::lazy_node::LazyNode;
 use clvmr::allocator::Allocator;
 use clvmr::chia_dialect::ChiaDialect;
-use clvmr::chia_dialect::NO_NEG_DIV as _no_neg_div;
 use clvmr::chia_dialect::NO_UNKNOWN_OPS as _no_unknown_ops;
 use clvmr::cost::Cost;
 use clvmr::node::Node;
@@ -23,9 +22,6 @@ pub struct Flag;
 
 #[wasm_bindgen]
 impl Flag {
-    #[wasm_bindgen]
-    pub fn no_neg_div() -> u32 { _no_neg_div }
-
     #[wasm_bindgen]
     pub fn no_unknown_ops() -> u32 { _no_unknown_ops }
 }

--- a/wasm/tests/index.js
+++ b/wasm/tests/index.js
@@ -107,20 +107,15 @@ test_case("Test divmod", function(){
     expect_equal(sexp.pair[1].atom.toString(), numsToByteStr([-1]));
 });
 
-test_case("Test div and NO_NEG_DIV flag", function(){
+test_case("Test negative div", function(){
     // (/ (q . 5) (q . -3))
     const prog = bytesFromHex("ff13ffff0105ffff0181fd80");
     // ()
     const arg = bytesFromHex("80");
     // 100,000,000,000
     const max_cost = BigInt("100000000000");
-    let flag = 0;
-    const [cost, sexp] = wasm.run_chia_program(prog, arg, max_cost, flag);
-    expect_equal(sexp.atom.toString(), numsToByteStr([-2]));
-    // NO_NEG_DIV flag set
-    flag = wasm.Flag.no_neg_div();
     expect_throw(function(){
-        wasm.run_chia_program(prog, arg, max_cost, flag);
+        wasm.run_chia_program(prog, arg, max_cost, 0);
     });
 });
 

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -6,7 +6,7 @@ use clvmr::cost::Cost;
 use clvmr::reduction::Response;
 use clvmr::run_program::run_program;
 use clvmr::serde::{node_from_bytes, serialized_length_from_bytes};
-use clvmr::{LIMIT_HEAP, LIMIT_STACK, MEMPOOL_MODE, NO_NEG_DIV, NO_UNKNOWN_OPS};
+use clvmr::{LIMIT_HEAP, LIMIT_STACK, MEMPOOL_MODE, NO_UNKNOWN_OPS};
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 
@@ -44,7 +44,6 @@ fn clvm_rs(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(run_serialized_chia_program, m)?)?;
     m.add_function(wrap_pyfunction!(serialized_length, m)?)?;
 
-    m.add("NO_NEG_DIV", NO_NEG_DIV)?;
     m.add("NO_UNKNOWN_OPS", NO_UNKNOWN_OPS)?;
     m.add("LIMIT_HEAP", LIMIT_HEAP)?;
     m.add("LIMIT_STACK", LIMIT_STACK)?;


### PR DESCRIPTION
now that the soft-fork has activated.

This patch removes all logic around having two separate `op_div` functions and makes a single one with the `NO_NEG_DIV` behavior. The test cases for the `/`-operator are updated to expect the no-negative-div behavior.

Since the soft-fork to disallow division with negative numbers activated a long time ago, there is no reason to keep this flag around anymore. It only creates a risk of forgetting to pass it in.