### PR TITLE
make softfork invocations fail in mempool mode

### DIFF
--- a/src/chia_dialect.rs
+++ b/src/chia_dialect.rs
@@ -85,7 +85,13 @@ impl Dialect for ChiaDialect {
             33 => op_any,
             34 => op_all,
             // 35 ---
-            36 => op_softfork,
+            36 => {
+                if (self.flags & NO_UNKNOWN_OPS) != 0 {
+                    return err(o, "no softfork implemented");
+                } else {
+                    op_softfork
+                }
+            }
             _ => {
                 if (self.flags & NO_UNKNOWN_OPS) != 0 {
                     return err(o, "unimplemented operator");

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -409,6 +409,7 @@ pub fn run_program_with_counters<'a, D: Dialect>(
 struct RunProgramTest {
     prg: &'static str,
     args: &'static str,
+    flags: u32,
     result: Option<&'static str>,
     cost: Cost,
     err: &'static str,
@@ -423,6 +424,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(a (q 2 2 (c 2 (c 5 (c 11 ())))) (c (q 2 (i (= 11 ()) (q 1 . 1) (q 18 5 (a 2 (c 2 (c 5 (c (- 11 (q . 1)) ())))))) 1) 1))",
         args: "(5033 1000)",
+        flags: 0,
         result: Some("0x024d4f505f1f813ca5e0ae8805bad8707347e65c5f7595da4852be5074288431d1df11a0c326d249f1f52ee051579403d1d0c23a7a1e9af18b7d7dc4c63c73542863c434ae9dfa80141a30cf4acee0d6c896aa2e64ea748404427a3bdaa1b97e4e09b8f5e4f8e9c568a4fc219532dbbad5ec54476d19b7408f8e7e7df16b830c20a1e83d90cc0620b0677b7606307f725539ef223561cdb276baf8e92156ee6492d97159c8f64768349ea7e219fd07fa818a59d81d0563b140396402f0ff758840da19808440e0a57c94c48ef84b4ab7ca8c5f010b69b8f443b12b50bd91bdcf2a96208ddac283fa294d6a99f369d57ab41d03eab5bb4809223c141ad94378516e6766a5054e22e997e260978af68a86893890d612f081b40d54fd1e940af35c0d7900c9a917e2458a61ef8a83f7211f519b2c5f015dfa7c2949ef8bedd02d3bad64ca9b2963dc2bb79f24092331133a7a299872079b9d0422b8fc0eeba4e12c7667ac7282cc6ff98a7c670614c9fce5a061b8d5cd4dd3c6d62d245688b62f9713dc2604bdd5bbc85c070c51f784a9ebac0e0eaa2e29e82d93e570887aa7e1a9d25baf0b2c55a4615f35ec0dbe9baa921569700f95e10cd2d4f6ba152a2ac288c37b60980df33dadfa920fd43dbbf55a0b333b88a3237d954e33d80ed6582019faf51db5f1b52e392559323f8bdd945e7fc6cb8f97f2b8417cfc184d7bfbfa5314d4114f95b725847523f1848d13c28ad96662298ee4e2d87af23e7cb4e58d7a20a5c57ae6833b4a37dcafccca0245a0d6ef28f83200d74db390281e03dd3a8b782970895764c3fcef31c5ed6d0b6e4e796a62ad5654691eea0d9db351cc4fee63248405b24c98bd5e68e4a5e0ab11e90e3c7de270c594d3a35639d931853b7010c8c896f6b28b2af719e53da65da89d44b926b6f06123c9217a43be35d751516bd02c18c4f868a2eae78ae3c6deab1115086c8ce58414db4561865d17ab95c7b3d4e1bfc6d0a4d3fbf5f20a0a7d77a9270e4da354c588da55b0063aec76654019ffb310e1503d99a7bc81ccdf5f8b15c8638156038624cf35988d8420bfdb59184c4b86bf5448df65c44aedc2e98eead7f1ba4be8f402baf12d41076b8f0991cfc778e04ba2c05d1440c70488ffaeefde537064035037f729b683e8ff1b3d0b4aa26a2b30bcaa9379f7fcc7072ff9a2c3e801c5979b0ab3e7acf89373de642d596f26514b9fa213ca217181a8429ad69d14445a822b16818c2509480576dc0ff7bac48c557e6d1883039f4daf873fa4f9a4d849130e2e4336049cfaf9e69a7664f0202b901cf07c7065c4dc93c46f98c5ea5c9c9d911b733093490da3bf1c95f43cd18b7be3798535a55ac6da3442946a268b74bde1349ca9807c41d90c7ec218a17efd2c21d5fcd720501f8a488f1dfba0a423dfdb2a877707b77930e80d734ceabcdb24513fad8f2e2470604d041df083bf184edd0e9720dd2b608b1ee1df951d7ce8ec671317b4f5a3946aa75280658b4ef77b3f504ce73e7ecac84eec3c2b45fb62f6fbd5ab78c744abd3bf5d0ab37d7b19124d2470d53db09ddc1f9dd9654b0e6a3a44c95d0a5a5e061bd24813508d3d1c901544dc3e6b84ca38dd2fde5ea60a57cbc12428848c4e3f6fd4941ebd23d709a717a090dd01830436659f7c20fd2d70c916427e9f3f12ac479128c2783f02a9824aa4e31de133c2704e049a50160f656e28aa0a2615b32bd48bb5d5d13d363a487324c1e9b8703be938bc545654465c9282ad5420978263b3e3ba1bb45e1a382554ac68e5a154b896c9c4c2c3853fbbfc877c4fb7dc164cc420f835c413839481b1d2913a68d206e711fb19b284a7bb2bd2033531647cf135833a0f3026b0c1dc0c184120d30ef4865985fdacdfb848ab963d2ae26a784b7b6a64fdb8feacf94febed72dcd0a41dc12be26ed79af88f1d9cba36ed1f95f2da8e6194800469091d2dfc7b04cfe93ab7a7a888b2695bca45a76a1458d08c3b6176ab89e7edc56c7e01142adfff944641b89cd5703a911145ac4ec42164d90b6fcd78b39602398edcd1f935485894fb8a1f416e031624806f02fbd07f398dbfdd48b86dfacf2045f85ecfe5bb1f01fae758dcdb4ae3b1e2aac6f0878f700d1f430b8ca47c9d8254059bd5c006042c4605f33ca98b41"),
         cost: 15073165,
         err: "",
@@ -431,6 +433,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(= (point_add (pubkey_for_exp (q . -2)) (pubkey_for_exp (q . 5))) (pubkey_for_exp (q . 3)))",
         args: "()",
+        flags: 0,
         result: Some("1"),
         cost: 6768556,
         err: "",
@@ -438,6 +441,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(= (point_add (pubkey_for_exp (q . 2)) (pubkey_for_exp (q . 3))) (pubkey_for_exp (q . 5)))",
         args: "()",
+        flags: 0,
         result: Some("1"),
         cost: 6768556,
         err: "",
@@ -445,6 +449,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(point_add (pubkey_for_exp (q . 1)) (pubkey_for_exp (q . 2)))",
         args: "()",
+        flags: 0,
         result: Some("0x89ece308f9d1f0131765212deca99697b112d61f9be9a5f1f3780a51335b3ff981747a0b2ca2179b96d2c0c9024e5224"),
         cost: 5442073,
         err: "",
@@ -452,6 +457,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(f (f (q . ((100 200 300) 400 500))))",
         args: "()",
+        flags: 0,
         result: Some("0x64"),
         cost: 82,
         err: "",
@@ -459,6 +465,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(= (f 1) (+ (f (r 1)) (f (r (r 1)))))",
         args: "(7 3 3)",
+        flags: 0,
         result: Some("()"),
         cost: 1194,
         err: "",
@@ -466,6 +473,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(= (f 1) (+ (f (r 1)) (f (r (r 1)))))",
         args: "(7 3 4)",
+        flags: 0,
         result: Some("1"),
         cost: 1194,
         err: "",
@@ -473,6 +481,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(i (f (r (r 1))) (f 1) (f (r 1)))",
         args: "(200 300 400)",
+        flags: 0,
         result: Some("0x00c8"),
         cost: 352,
         err: "",
@@ -480,6 +489,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(i (f (r (r 1))) (f 1) (f (r 1)))",
         args: "(200 300 1)",
+        flags: 0,
         result: Some("0x00c8"),
         cost: 352,
         err: "",
@@ -487,6 +497,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(r (r (q . ((100 200 300) 400 500))))",
         args: "()",
+        flags: 0,
         result: Some("(500)"),
         cost: 82,
         err: "",
@@ -494,6 +505,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(* (q . 10000000000000000000000000000000000) (q . 10000000000000000000000000000000) (q . 100000000000000000000000000000000000000) (q . 1000000000000000000000000000000) (q . 1000000000000000000000000000000) (q . 1000000000000000000000000000000) (q . 1000000000000000000000000000000) (q . 1000000000000000000000000000000) (q . 1000000000000000000000000000000) (q . 1000000000000000000000000000000) (q . 1000000000000000000000000000000) (q . 1000000000000000000000000000000) (q . 1000000000000000000000000000000) (q . 1000000000000000000000000000000) (q . 1000000000000000000000000000000))",
         args: "()",
+        flags: 0,
         result: Some("0x04261a5c969abab851babdb4f178e63bf2ed3879fc13a4c75622d73c909440a4763849b52e49cd2522500f555f6a3131775f93ddcf24eda7a1dbdf828a033626da873caaaa880a9121f4c44a157973f60443dc53bc99ac12d5bd5fa20a88320ae2ccb8e1b5e792cbf0d001bb0fbd7765d3936e412e2fc8f1267833237237fcb638dda0a7aa674680000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"),
         cost: 24255,
         err: "",
@@ -503,6 +515,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(a (q 0x0fffffffff) (q ()))",
         args: "()",
+        flags: 0,
         result: None,
         cost: 0,
         err: "invalid operator",
@@ -510,6 +523,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(a (q . 0) (q . 1) (q . 2))",
         args: "()",
+        flags: 0,
         result: None,
         cost: 0,
         err: "apply requires exactly 2 parameters",
@@ -517,6 +531,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(a (q 0x00ffffffffffffffffffff00) (q ()))",
         args: "()",
+        flags: 0,
         result: None,
         cost: 0,
         err: "invalid operator",
@@ -524,6 +539,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(a (q . 1))",
         args: "()",
+        flags: 0,
         result: None,
         cost: 0,
         err: "apply requires exactly 2 parameters",
@@ -531,6 +547,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(a (q . 1) (q . (100 200)))",
         args: "()",
+        flags: 0,
         result: Some("(100 200)"),
         cost: 175,
         err: "",
@@ -538,6 +555,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(a (q . (+ 2 5)) (q . (20 30)))",
         args: "()",
+        flags: 0,
         result: Some("50"),
         cost: 987,
         err: "",
@@ -545,6 +563,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "((c (q . (+ (q . 50) 1)) (q . 500)))",
         args: "()",
+        flags: 0,
         result: None,
         cost: 0,
         err: "in ((X)...) syntax X must be lone atom",
@@ -552,6 +571,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "((#c) (q . 3) (q . 4))",
         args: "()",
+        flags: 0,
         result: Some("((1 . 3) 1 . 4)"),
         cost: 140,
         err: "",
@@ -559,6 +579,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(a (q . 2) (q . (3 4 5)))",
         args: "()",
+        flags: 0,
         result: Some("3"),
         cost: 179,
         err: "",
@@ -570,6 +591,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "0",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("()"),
         cost: 44,
         err: "",
@@ -578,6 +600,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "1",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("(((8 . 12) 10 . 14) (9 . 13) 11 . 15)"),
         cost: 44,
         err: "",
@@ -586,6 +609,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "2",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("((8 . 12) 10 . 14)"),
         cost: 48,
         err: "",
@@ -594,6 +618,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "3",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("((9 . 13) 11 . 15)"),
         cost: 48,
         err: "",
@@ -602,6 +627,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "4",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("(8 . 12)"),
         cost: 52,
         err: "",
@@ -610,6 +636,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "5",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("(9 . 13)"),
         cost: 52,
         err: "",
@@ -618,6 +645,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "6",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("(10 . 14)"),
         cost: 52,
         err: "",
@@ -626,6 +654,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "7",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("(11 . 15)"),
         cost: 52,
         err: "",
@@ -633,6 +662,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "8",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("8"),
         cost: 56,
         err: "",
@@ -640,6 +670,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "9",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("9"),
         cost: 56,
         err: "",
@@ -647,6 +678,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "10",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("10"),
         cost: 56,
         err: "",
@@ -654,6 +686,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "11",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("11"),
         cost: 56,
         err: "",
@@ -661,6 +694,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "12",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("12"),
         cost: 56,
         err: "",
@@ -668,6 +702,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "13",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("13"),
         cost: 56,
         err: "",
@@ -675,6 +710,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "14",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("14"),
         cost: 56,
         err: "",
@@ -682,6 +718,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "15",
         args: "(((8 . 12) . (10 . 14)) . ((9 . 13) . (11 . 15)))",
+        flags: 0,
         result: Some("15"),
         cost: 56,
         err: "",
@@ -689,6 +726,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
         args: "(((0x1337 . (0x1337 . (42 . 0x1337))) . 0x1337) . 0x1337)",
+        flags: 0,
         result: Some("(((0x1337 . (0x1337 . (42 . 0x1337))) . 0x1337) . 0x1337)"),
         cost: 536,
         err: "",
@@ -696,6 +734,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "0x0000C8C141AB3121E776",
         args: "((0x1337 . (0x1337 . ((0x1337 . (0x1337 . (0x1337 . ((0x1337 . (0x1337 . (0x1337 . (((0x1337 . (0x1337 . (0x1337 . (0x1337 . (((((0x1337 . (((0x1337 . ((((0x1337 . (0x1337 . (((0x1337 . (0x1337 . ((0x1337 . ((0x1337 . ((0x1337 . (0x1337 . ((((((0x1337 . ((0x1337 . ((((((0x1337 . (0x1337 . ((((0x1337 . (((0x1337 . 42) . 0x1337) . 0x1337)) . 0x1337) . 0x1337) . 0x1337))) . 0x1337) . 0x1337) . 0x1337) . 0x1337) . 0x1337)) . 0x1337)) . 0x1337) . 0x1337) . 0x1337) . 0x1337) . 0x1337))) . 0x1337)) . 0x1337)) . 0x1337))) . 0x1337) . 0x1337))) . 0x1337) . 0x1337) . 0x1337)) . 0x1337) . 0x1337)) . 0x1337) . 0x1337) . 0x1337) . 0x1337))))) . 0x1337) . 0x1337)))) . 0x1337)))) . 0x1337))) . 0x1337)",
+        flags: 0,
         result: Some("42"),
         cost: 304,
         err: "",
@@ -703,6 +742,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "7708975405620101644641102810267383005",
         args: "(0x1337 . ((0x1337 . (0x1337 . (0x1337 . ((0x1337 . (0x1337 . (((0x1337 . ((0x1337 . (0x1337 . (0x1337 . (0x1337 . (0x1337 . ((0x1337 . (0x1337 . ((0x1337 . (((0x1337 . (0x1337 . (0x1337 . ((0x1337 . (((0x1337 . (((0x1337 . (0x1337 . (0x1337 . (0x1337 . ((0x1337 . ((0x1337 . (((((0x1337 . ((0x1337 . ((0x1337 . (0x1337 . (0x1337 . (((0x1337 . (0x1337 . ((0x1337 . (0x1337 . ((((0x1337 . (0x1337 . (0x1337 . (0x1337 . (((((0x1337 . (0x1337 . (0x1337 . (0x1337 . (0x1337 . (((((0x1337 . (((((0x1337 . ((0x1337 . (0x1337 . ((((0x1337 . ((((0x1337 . ((0x1337 . ((0x1337 . ((0x1337 . (0x1337 . (0x1337 . ((((0x1337 . (0x1337 . ((0x1337 . (((0x1337 . (0x1337 . (((0x1337 . (0x1337 . (0x1337 . (42 . 0x1337)))) . 0x1337) . 0x1337))) . 0x1337) . 0x1337)) . 0x1337))) . 0x1337) . 0x1337) . 0x1337)))) . 0x1337)) . 0x1337)) . 0x1337)) . 0x1337) . 0x1337) . 0x1337)) . 0x1337) . 0x1337) . 0x1337))) . 0x1337)) . 0x1337) . 0x1337) . 0x1337) . 0x1337)) . 0x1337) . 0x1337) . 0x1337) . 0x1337)))))) . 0x1337) . 0x1337) . 0x1337) . 0x1337))))) . 0x1337) . 0x1337) . 0x1337))) . 0x1337))) . 0x1337) . 0x1337)))) . 0x1337)) . 0x1337)) . 0x1337) . 0x1337) . 0x1337) . 0x1337)) . 0x1337)) . 0x1337))))) . 0x1337) . 0x1337)) . 0x1337) . 0x1337)) . 0x1337)))) . 0x1337) . 0x1337)) . 0x1337))) . 0x1337)))))) . 0x1337)) . 0x1337) . 0x1337))) . 0x1337)))) . 0x1337))",
+        flags: 0,
         result: Some("42"),
         cost: 532,
         err: "",
@@ -710,6 +750,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "1",
         args: "1",
+        flags: 0,
         result: Some("1"),
         cost: 44,
         err: "",
@@ -717,9 +758,69 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(> 3 3)",
         args: "()",
+        flags: 0,
         result: None,
         cost: 0,
         err: "path into atom",
+    },
+
+    // ## SOFTFORK
+
+    // in mempool mode, softfork is not allowed, because we haven't implemented
+    // any softfork operators yet
+    RunProgramTest {
+        prg: "(softfork (q . 939) (q 88))",
+        args: "()",
+        flags: NO_UNKNOWN_OPS,
+        result: None,
+        cost: 0,
+        err: "no softfork implemented",
+    },
+    // in consensus mode we just accept any softfork program, even if we don't
+    // know what it does
+    RunProgramTest {
+        prg: "(softfork (q . 939) (q 0x0fffffffff) (q ()))",
+        args: "()",
+        flags: 0,
+        result: Some("()"),
+        cost: 1000,
+        err: "",
+    },
+    // the cost argument may not exceed the max cost
+    RunProgramTest {
+        prg: "(softfork (q . 939) (q 0x0fffffffff) (q ()))",
+        args: "()",
+        flags: 0,
+        result: None,
+        cost: 900,
+        err: "cost exceeded",
+    },
+    // the cost parameter is mandatory
+    RunProgramTest {
+        prg: "(softfork)",
+        args: "()",
+        flags: 0,
+        result: None,
+        cost: 0,
+        err: "softfork takes at least 1 argument",
+    },
+    // negative costs are not allowed
+    RunProgramTest {
+        prg: "(softfork (q . -1))",
+        args: "()",
+        flags: 0,
+        result: None,
+        cost: 0,
+        err: "cost must be > 0",
+    },
+    // zero costs are not allowed
+    RunProgramTest {
+        prg: "(softfork (q . 0))",
+        args: "()",
+        flags: 0,
+        result: None,
+        cost: 0,
+        err: "cost must be > 0",
     },
 ];
 
@@ -728,6 +829,9 @@ fn check(res: (NodePtr, &str)) -> NodePtr {
     assert_eq!(res.1, "");
     res.0
 }
+
+#[cfg(test)]
+use crate::chia_dialect::NO_UNKNOWN_OPS;
 
 #[test]
 fn test_run_program() {
@@ -741,7 +845,7 @@ fn test_run_program() {
         let args = check(parse_exp(&mut allocator, &t.args));
         let expected_result = &t.result.map(|v| check(parse_exp(&mut allocator, v)));
 
-        let dialect = ChiaDialect::new(0);
+        let dialect = ChiaDialect::new(t.flags);
         println!("prg: {}", t.prg);
         match run_program(&mut allocator, &dialect, program, args, t.cost) {
             Ok(Reduction(cost, prg_result)) => {
@@ -758,7 +862,6 @@ fn test_run_program() {
                 println!("FAILED: {}", err.1);
                 assert_eq!(err.1, t.err);
                 assert!(expected_result.is_none());
-                assert_eq!(t.cost, 0);
             }
         }
     }


### PR DESCRIPTION
since we haven't implemented any softforks yet, farmers should not accept unknown softforks