### PR TITLE
raise the abstraction level of Allocator to support Numbers directly

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -1,11 +1,13 @@
 use crate::allocator::{Allocator, NodePtr};
-use crate::node::Node;
 use crate::reduction::EvalErr;
 
 use num_bigint::BigInt;
 pub type Number = BigInt;
 
-pub fn ptr_from_number(allocator: &mut Allocator, item: &Number) -> Result<NodePtr, EvalErr> {
+// This low-level conversion function is meant to be used by the Allocator, for
+// logic interacting with the CLVM heap/allocator, use new_number() and number()
+// instead.
+pub fn node_from_number(allocator: &mut Allocator, item: &Number) -> Result<NodePtr, EvalErr> {
     let bytes: Vec<u8> = item.to_signed_bytes_be();
     let mut slice = bytes.as_slice();
 
@@ -19,13 +21,9 @@ pub fn ptr_from_number(allocator: &mut Allocator, item: &Number) -> Result<NodeP
     allocator.new_atom(slice)
 }
 
-impl From<&Node<'_>> for Option<Number> {
-    fn from(item: &Node) -> Self {
-        let v: &[u8] = item.atom()?;
-        Some(number_from_u8(v))
-    }
-}
-
+// This low-level conversion function is meant to be used by the Allocator, for
+// logic interacting with the CLVM heap/allocator, use new_number() and number()
+// instead.
 pub fn number_from_u8(v: &[u8]) -> Number {
     let len = v.len();
     if len == 0 {
@@ -36,62 +34,62 @@ pub fn number_from_u8(v: &[u8]) -> Number {
 }
 
 #[test]
-fn test_ptr_from_number() {
+fn test_node_from_number() {
     let mut a = Allocator::new();
 
     // 0 is encoded as an empty string
     let num = number_from_u8(&[0]);
-    let ptr = ptr_from_number(&mut a, &num).unwrap();
+    let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "0");
     assert_eq!(a.atom(ptr).len(), 0);
 
     let num = number_from_u8(&[1]);
-    let ptr = ptr_from_number(&mut a, &num).unwrap();
+    let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "1");
     assert_eq!(&[1], &a.atom(ptr));
 
     // leading zeroes are redundant
     let num = number_from_u8(&[0, 0, 0, 1]);
-    let ptr = ptr_from_number(&mut a, &num).unwrap();
+    let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "1");
     assert_eq!(&[1], &a.atom(ptr));
 
     let num = number_from_u8(&[0x00, 0x00, 0x80]);
-    let ptr = ptr_from_number(&mut a, &num).unwrap();
+    let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "128");
     assert_eq!(&[0x00, 0x80], &a.atom(ptr));
 
     // A leading zero is necessary to encode a positive number with the
     // penultimate byte's most significant bit set
     let num = number_from_u8(&[0x00, 0xff]);
-    let ptr = ptr_from_number(&mut a, &num).unwrap();
+    let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "255");
     assert_eq!(&[0x00, 0xff], &a.atom(ptr));
 
     let num = number_from_u8(&[0x7f, 0xff]);
-    let ptr = ptr_from_number(&mut a, &num).unwrap();
+    let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "32767");
     assert_eq!(&[0x7f, 0xff], &a.atom(ptr));
 
     // the first byte is redundant, it's still -1
     let num = number_from_u8(&[0xff, 0xff]);
-    let ptr = ptr_from_number(&mut a, &num).unwrap();
+    let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "-1");
     assert_eq!(&[0xff], &a.atom(ptr));
 
     let num = number_from_u8(&[0xff]);
-    let ptr = ptr_from_number(&mut a, &num).unwrap();
+    let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "-1");
     assert_eq!(&[0xff], &a.atom(ptr));
 
     let num = number_from_u8(&[0x00, 0x80, 0x00]);
     assert_eq!(format!("{}", num), "32768");
-    let ptr = ptr_from_number(&mut a, &num).unwrap();
+    let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(&[0x00, 0x80, 0x00], &a.atom(ptr));
 
     let num = number_from_u8(&[0x00, 0x40, 0x00]);
     assert_eq!(format!("{}", num), "16384");
-    let ptr = ptr_from_number(&mut a, &num).unwrap();
+    let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(&[0x40, 0x00], &a.atom(ptr));
 }
 

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -4,7 +4,6 @@ use crate::cost::Cost;
 use crate::dialect::{Dialect, OperatorSet};
 use crate::err_utils::err;
 use crate::node::Node;
-use crate::number::{ptr_from_number, Number};
 use crate::op_utils::uint_atom;
 use crate::reduction::{EvalErr, Reduction, Response};
 
@@ -465,9 +464,7 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
         // max_cost is always in effect, and necessary to prevent wrap-around of
         // the cost integer.
         let max_cost = if max_cost == 0 { Cost::MAX } else { max_cost };
-
-        let max_cost_number: Number = max_cost.into();
-        let max_cost_ptr = ptr_from_number(self.allocator, &max_cost_number)?;
+        let max_cost_ptr = self.allocator.new_number(max_cost.into())?;
 
         let mut cost: Cost = 0;
 

--- a/src/test_ops.rs
+++ b/src/test_ops.rs
@@ -6,7 +6,7 @@ use crate::more_ops::{
     op_logand, op_logior, op_lognot, op_logxor, op_lsh, op_multiply, op_not, op_point_add,
     op_pubkey_for_exp, op_sha256, op_strlen, op_substr, op_subtract,
 };
-use crate::number::{ptr_from_number, Number};
+use crate::number::Number;
 use crate::reduction::{EvalErr, Reduction, Response};
 
 use hex::FromHex;
@@ -903,7 +903,7 @@ fn parse_atom(a: &mut Allocator, v: &str) -> NodePtr {
     }
 
     if let Ok(num) = Number::from_str_radix(v, 10) {
-        ptr_from_number(a, &num).unwrap()
+        a.new_number(num).unwrap()
     } else {
         let v = if v.starts_with("#") { &v[1..] } else { v };
         match v {


### PR DESCRIPTION
not just Atoms as byte buffers.

The idea is to open up the possibility for the allocator to store atoms in their "native" forms, and only lazily convert them to a requested form. Hopefully reducing the time spent serializing and deserializing numbers.

One common reason to ask for bytes for an atom is to account for the cost of operations, based on the number of bytes in the atom. To avoid forcing a serialization for this case, the Allocator also gains a function to request the length of an atom directly. This is presumably cheaper than serializing a number, just to count the number of bytes.

The utility function `int_atom()` was extended to return, not just the `Number` but also the length of the atom, for cost calculation purposes.

This change further sets a precedence to also support other types natively, such as G1, G2 and Gt points.