### PR TITLE
add option to make BLS extensions available outside the softfork operator

### DIFF
--- a/fuzz/fuzz_targets/run_program.rs
+++ b/fuzz/fuzz_targets/run_program.rs
@@ -3,7 +3,8 @@ use libfuzzer_sys::fuzz_target;
 
 use clvmr::allocator::Allocator;
 use clvmr::chia_dialect::{
-    ChiaDialect, ENABLE_BLS_OPS, LIMIT_HEAP, LIMIT_STACK, MEMPOOL_MODE, NO_UNKNOWN_OPS,
+    ChiaDialect, ENABLE_BLS_OPS, ENABLE_BLS_OPS_OUTSIDE_GUARD, LIMIT_HEAP, LIMIT_STACK,
+    MEMPOOL_MODE, NO_UNKNOWN_OPS,
 };
 use clvmr::cost::Cost;
 use clvmr::reduction::Reduction;
@@ -28,6 +29,7 @@ fuzz_target!(|data: &[u8]| {
         LIMIT_HEAP,
         LIMIT_STACK,
         ENABLE_BLS_OPS,
+        ENABLE_BLS_OPS_OUTSIDE_GUARD,
         MEMPOOL_MODE,
     ] {
         let dialect = ChiaDialect::new(flags);

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -566,6 +566,8 @@ use crate::test_ops::parse_exp;
 #[cfg(test)]
 use crate::chia_dialect::ENABLE_BLS_OPS;
 #[cfg(test)]
+use crate::chia_dialect::ENABLE_BLS_OPS_OUTSIDE_GUARD;
+#[cfg(test)]
 use crate::chia_dialect::NO_UNKNOWN_OPS;
 
 #[cfg(test)]
@@ -1170,6 +1172,35 @@ const TEST_CASES: &[RunProgramTest] = &[
         result: Some("()"),
         cost: 1346,
         err: "",
+    },
+
+    // coinid operator after hardfork, where coinid is available outside the
+    // softfork guard.
+    RunProgramTest {
+        prg: "(coinid (q . 0x1234500000000000000000000000000000000000000000000000000000000000) (q . 0x6789abcdef000000000000000000000000000000000000000000000000000000) (q . 123456789))",
+        args: "()",
+        flags: ENABLE_BLS_OPS_OUTSIDE_GUARD,
+        result: Some("0x69bfe81b052bfc6bd7f3fb9167fec61793175b897c16a35827f947d5cc98e4bc"),
+        cost: 694,
+        err: "",
+    },
+    RunProgramTest {
+        prg: "(coinid (q . 0x1234500000000000000000000000000000000000000000000000000000000000) (q . 0x6789abcdef000000000000000000000000000000000000000000000000000000) (q . 0x000123456789))",
+        args: "()",
+        flags: ENABLE_BLS_OPS_OUTSIDE_GUARD,
+        result: None,
+        cost: 694,
+        err: "coinid: invalid amount (may not have redundant leading zero)",
+    },
+    // make sure the coinid operator is not available unless the flag is
+    // specified
+    RunProgramTest {
+        prg: "(coinid (q . 0x1234500000000000000000000000000000000000000000000000000000000000) (q . 0x6789abcdef000000000000000000000000000000000000000000000000000000) (q . 0x000123456789))",
+        args: "()",
+        flags: NO_UNKNOWN_OPS,
+        result: None,
+        cost: 694,
+        err: "unimplemented operator",
     },
 ];
 


### PR DESCRIPTION
The BLS extensions only contain `coinid` for now. This is a hard fork and intended for when the 2.0 hard fork activates.