### PR TITLE
Set specifically the macos deployment target to 10.14

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,6 +46,8 @@ jobs:
 
     - name: Build MacOs with maturin on Python ${{ matrix.python }}
       if: startsWith(matrix.os, 'macos')
+      env:
+        MACOSX_DEPLOYMENT_TARGET: '10.15'
       run: |
         python -m venv venv
         ln -s venv/bin/activate

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Build MacOs with maturin on Python ${{ matrix.python }}
       if: startsWith(matrix.os, 'macos')
       env:
-        MACOSX_DEPLOYMENT_TARGET: '10.15'
+        MACOSX_DEPLOYMENT_TARGET: '10.14'
       run: |
         python -m venv venv
         ln -s venv/bin/activate


### PR DESCRIPTION
Specifically setting the deployment target prevents maturin from doing something strange like publishing a wheel that claims to work on macOS 10.7 when it almost certainly doesn't

Set the target to 10.14 to match the setting on all other wheels