### PR TITLE
export the new BLS flags from the root of the crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,10 @@ pub use allocator::Allocator;
 pub use chia_dialect::ChiaDialect;
 pub use run_program::run_program;
 
-pub use chia_dialect::{LIMIT_HEAP, LIMIT_STACK, MEMPOOL_MODE, NO_UNKNOWN_OPS};
+pub use chia_dialect::{
+    ENABLE_BLS_OPS, ENABLE_BLS_OPS_OUTSIDE_GUARD, LIMIT_HEAP, LIMIT_STACK, MEMPOOL_MODE,
+    NO_UNKNOWN_OPS,
+};
 
 #[cfg(feature = "counters")]
 pub use run_program::run_program_with_counters;


### PR DESCRIPTION
just like we export all other public symbols from the root, also do so with the new flags that were added recently