### PR TITLE
make G1 and G2 points first class objects in the Allocator

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,6 +1,7 @@
 use crate::err_utils::err;
 use crate::number::{node_from_number, number_from_u8, Number};
 use crate::reduction::EvalErr;
+use bls12_381::{G1Affine, G1Projective, G2Affine, G2Projective};
 
 pub type NodePtr = i32;
 
@@ -152,6 +153,16 @@ impl Allocator {
         node_from_number(self, &v)
     }
 
+    pub fn new_g1(&mut self, g1: G1Projective) -> Result<NodePtr, EvalErr> {
+        let g1: G1Affine = g1.into();
+        self.new_atom(&g1.to_compressed())
+    }
+
+    pub fn new_g2(&mut self, g2: G2Projective) -> Result<NodePtr, EvalErr> {
+        let g2: G2Affine = g2.into();
+        self.new_atom(&g2.to_compressed())
+    }
+
     pub fn new_pair(&mut self, first: NodePtr, rest: NodePtr) -> Result<NodePtr, EvalErr> {
         let r = self.pair_vec.len() as i32;
         if self.pair_vec.len() == self.pair_limit {
@@ -243,6 +254,44 @@ impl Allocator {
 
     pub fn number(&self, node: NodePtr) -> Number {
         number_from_u8(self.atom(node))
+    }
+
+    pub fn g1(&self, node: NodePtr) -> Result<G1Projective, EvalErr> {
+        let blob = match self.sexp(node) {
+            SExp::Atom(buf) => self.buf(&buf),
+            _ => {
+                return err(node, "pair found, expected G1 point");
+            }
+        };
+        if blob.len() != 48 {
+            return err(node, "atom is not G1 size, 48 bytes");
+        }
+
+        let affine: Option<G1Affine> =
+            G1Affine::from_compressed(blob.try_into().expect("G1 slice is not 48 bytes")).into();
+        match affine {
+            Some(point) => Ok(G1Projective::from(point)),
+            None => err(node, "atom is not a G1 point"),
+        }
+    }
+
+    pub fn g2(&self, node: NodePtr) -> Result<G2Projective, EvalErr> {
+        let blob = match self.sexp(node) {
+            SExp::Atom(buf) => self.buf(&buf),
+            _ => {
+                return err(node, "pair found, expected G2 point");
+            }
+        };
+        if blob.len() != 96 {
+            return err(node, "atom is not G2 size, 96 bytes");
+        }
+
+        let affine: Option<G2Affine> =
+            G2Affine::from_compressed(blob.try_into().expect("G2 slice is not 96 bytes")).into();
+        match affine {
+            Some(point) => Ok(G2Projective::from(point)),
+            None => err(node, "atom is not a G2 point"),
+        }
     }
 
     pub fn sexp(&self, node: NodePtr) -> SExp {
@@ -551,4 +600,309 @@ fn test_checkpoints() {
 
     // since atom2 was removed, atom3 should actually be using that slot
     assert_eq!(atom2, atom3);
+}
+
+#[cfg(test)]
+fn test_g1(a: &Allocator, n: NodePtr) -> EvalErr {
+    a.g1(n).unwrap_err()
+}
+
+#[cfg(test)]
+fn test_g2(a: &Allocator, n: NodePtr) -> EvalErr {
+    a.g2(n).unwrap_err()
+}
+
+#[cfg(test)]
+type TestFun = fn(&Allocator, NodePtr) -> EvalErr;
+
+#[cfg(test)]
+#[rstest]
+#[case(test_g1, 0, "atom is not G1 size, 48 bytes")]
+#[case(test_g1, 3, "atom is not G1 size, 48 bytes")]
+#[case(test_g1, 47, "atom is not G1 size, 48 bytes")]
+#[case(test_g1, 49, "atom is not G1 size, 48 bytes")]
+#[case(test_g1, 48, "atom is not a G1 point")]
+#[case(test_g2, 0, "atom is not G2 size, 96 bytes")]
+#[case(test_g2, 3, "atom is not G2 size, 96 bytes")]
+#[case(test_g2, 95, "atom is not G2 size, 96 bytes")]
+#[case(test_g2, 97, "atom is not G2 size, 96 bytes")]
+#[case(test_g2, 96, "atom is not a G2 point")]
+fn test_point_size_error(#[case] fun: TestFun, #[case] size: usize, #[case] expected: &str) {
+    let mut a = Allocator::new();
+    let mut buf = Vec::<u8>::new();
+    buf.resize(size, 0xcc);
+    let n = a.new_atom(&buf).unwrap();
+    let r = fun(&mut a, n);
+    assert_eq!(r.0, n);
+    assert_eq!(r.1, expected.to_string());
+}
+
+#[cfg(test)]
+#[rstest]
+#[case(test_g1, "pair found, expected G1 point")]
+#[case(test_g2, "pair found, expected G2 point")]
+fn test_point_atom_pair(#[case] fun: TestFun, #[case] expected: &str) {
+    let mut a = Allocator::new();
+    let n = a.new_pair(a.null(), a.one()).unwrap();
+    let r = fun(&mut a, n);
+    assert_eq!(r.0, n);
+    assert_eq!(r.1, expected.to_string());
+}
+
+#[cfg(test)]
+#[rstest]
+#[case("97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb")]
+#[case("a572cbea904d67468808c8eb50a9450c9721db309128012543902d0ac358a62ae28f75bb8f1c7c42c39a8c5529bf0f4e")]
+fn test_g1_roundtrip(#[case] atom: &str) {
+    let mut a = Allocator::new();
+    let n = a.new_atom(&hex::decode(atom).unwrap()).unwrap();
+    let g1 = a.g1(n).unwrap();
+    assert_eq!(hex::encode(G1Affine::from(g1).to_compressed()), atom);
+
+    let g1_copy = a.new_g1(g1).unwrap();
+    let g1_atom = a.atom(g1_copy);
+    assert_eq!(hex::encode(g1_atom), atom);
+
+    // try interpreting the point as G1
+    assert_eq!(a.g2(n).unwrap_err().1, "atom is not G2 size, 96 bytes");
+    assert_eq!(
+        a.g2(g1_copy).unwrap_err().1,
+        "atom is not G2 size, 96 bytes"
+    );
+
+    // try interpreting the point as number
+    assert_eq!(a.number(n), number_from_u8(&hex::decode(atom).unwrap()));
+    assert_eq!(
+        a.number(g1_copy),
+        number_from_u8(&hex::decode(atom).unwrap())
+    );
+}
+
+#[cfg(test)]
+#[rstest]
+#[case("93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8")]
+#[case("aa4edef9c1ed7f729f520e47730a124fd70662a904ba1074728114d1031e1572c6c886f6b57ec72a6178288c47c335771638533957d540a9d2370f17cc7ed5863bc0b995b8825e0ee1ea1e1e4d00dbae81f14b0bf3611b78c952aacab827a053")]
+fn test_g2_roundtrip(#[case] atom: &str) {
+    let mut a = Allocator::new();
+    let n = a.new_atom(&hex::decode(atom).unwrap()).unwrap();
+    let g2 = a.g2(n).unwrap();
+    assert_eq!(hex::encode(G2Affine::from(g2).to_compressed()), atom);
+
+    let g2_copy = a.new_g2(g2).unwrap();
+    let g2_atom = a.atom(g2_copy);
+    assert_eq!(hex::encode(g2_atom), atom);
+
+    // try interpreting the point as G1
+    assert_eq!(a.g1(n).unwrap_err().1, "atom is not G1 size, 48 bytes");
+    assert_eq!(
+        a.g1(g2_copy).unwrap_err().1,
+        "atom is not G1 size, 48 bytes"
+    );
+
+    // try interpreting the point as number
+    assert_eq!(a.number(n), number_from_u8(&hex::decode(atom).unwrap()));
+    assert_eq!(
+        a.number(g2_copy),
+        number_from_u8(&hex::decode(atom).unwrap())
+    );
+}
+
+#[cfg(test)]
+use core::convert::TryFrom;
+
+#[cfg(test)]
+type MakeFun = fn(&mut Allocator, &[u8]) -> NodePtr;
+
+#[cfg(test)]
+fn make_buf(a: &mut Allocator, bytes: &[u8]) -> NodePtr {
+    a.new_atom(bytes).unwrap()
+}
+
+#[cfg(test)]
+fn make_number(a: &mut Allocator, bytes: &[u8]) -> NodePtr {
+    let v = number_from_u8(bytes);
+    a.new_number(v).unwrap()
+}
+
+#[cfg(test)]
+fn make_g1(a: &mut Allocator, bytes: &[u8]) -> NodePtr {
+    let v: G1Projective = G1Affine::from_compressed(bytes.try_into().unwrap())
+        .unwrap()
+        .into();
+    a.new_g1(v).unwrap()
+}
+
+#[cfg(test)]
+fn make_g2(a: &mut Allocator, bytes: &[u8]) -> NodePtr {
+    let v: G2Projective = G2Affine::from_compressed(bytes.try_into().unwrap())
+        .unwrap()
+        .into();
+    a.new_g2(v).unwrap()
+}
+
+#[cfg(test)]
+fn make_g1_fail(a: &mut Allocator, bytes: &[u8]) -> NodePtr {
+    assert!(<[u8; 48]>::try_from(bytes).is_err());
+    //assert!(G1Affine::from_compressed(bytes.try_into().unwrap()).is_none().unwrap_u8() != 0);
+    a.new_atom(bytes).unwrap()
+}
+
+#[cfg(test)]
+fn make_g2_fail(a: &mut Allocator, bytes: &[u8]) -> NodePtr {
+    assert!(<[u8; 96]>::try_from(bytes).is_err());
+    //assert!(G2Affine::from_compressed(bytes.try_into().unwrap()).is_none().unwrap_u8() != 0);
+    a.new_atom(bytes).unwrap()
+}
+
+#[cfg(test)]
+type CheckFun = fn(&Allocator, NodePtr, &[u8]);
+
+#[cfg(test)]
+fn check_buf(a: &Allocator, n: NodePtr, bytes: &[u8]) {
+    let buf = a.atom(n);
+    assert_eq!(buf, bytes);
+}
+
+#[cfg(test)]
+fn check_number(a: &Allocator, n: NodePtr, bytes: &[u8]) {
+    let num = a.number(n);
+    let v = number_from_u8(bytes);
+    assert_eq!(num, v);
+}
+
+#[cfg(test)]
+fn check_g1(a: &Allocator, n: NodePtr, bytes: &[u8]) {
+    let num = a.g1(n).unwrap();
+    let v: G1Projective = G1Affine::from_compressed(bytes.try_into().unwrap())
+        .unwrap()
+        .into();
+    assert_eq!(num, v);
+}
+
+#[cfg(test)]
+fn check_g2(a: &Allocator, n: NodePtr, bytes: &[u8]) {
+    let num = a.g2(n).unwrap();
+    let v: G2Projective = G2Affine::from_compressed(bytes.try_into().unwrap())
+        .unwrap()
+        .into();
+    assert_eq!(num, v);
+}
+
+#[cfg(test)]
+fn check_g1_fail(a: &Allocator, n: NodePtr, bytes: &[u8]) {
+    assert_eq!(a.g1(n).unwrap_err().0, n);
+    //assert!(G1Affine::from_compressed(bytes.try_into().unwrap()).is_none().unwrap_u8() != 0);
+    assert!(<[u8; 48]>::try_from(bytes).is_err());
+}
+
+#[cfg(test)]
+fn check_g2_fail(a: &Allocator, n: NodePtr, bytes: &[u8]) {
+    assert_eq!(a.g2(n).unwrap_err().0, n);
+    //assert!(G2Affine::from_compressed(bytes.try_into().unwrap()).is_none().unwrap_u8() != 0);
+    assert!(<[u8; 96]>::try_from(bytes).is_err());
+}
+
+#[cfg(test)]
+const EMPTY: &str = "";
+
+#[cfg(test)]
+const SMALL_BUF: &str = "133742";
+
+#[cfg(test)]
+const VALID_G1: &str = "a572cbea904d67468808c8eb50a9450c9721db309128012543902d0ac358a62ae28f75bb8f1c7c42c39a8c5529bf0f4e";
+
+#[cfg(test)]
+const VALID_G2: &str = "aa4edef9c1ed7f729f520e47730a124fd70662a904ba1074728114d1031e1572c6c886f6b57ec72a6178288c47c335771638533957d540a9d2370f17cc7ed5863bc0b995b8825e0ee1ea1e1e4d00dbae81f14b0bf3611b78c952aacab827a053";
+
+/*
+  We want to exercise round-tripping avery kind of value via every other kind
+  of value (as far as possible). e.g. Every value can round-trip through a byte buffer
+  or a number, but G1 cannot round-trip via G2.
+
+  +-----------+--------+--------+------+------+
+  | from / to | buffer | number | G1   | G2   |
+  +-----------+--------+--------+------+------+
+  | buffer    | o      | o      | -    | -    |
+  | number    | o      | o      | -    | -    |
+  | G1        | o      | o      | o    | -    |
+  | G2        | o      | o      | -    | o    |
+  +-----------+--------+--------+------+------+
+
+*/
+
+#[cfg(test)]
+#[rstest]
+// round trip empty buffer
+#[case(EMPTY, make_buf, check_buf)]
+#[case(EMPTY, make_buf, check_number)]
+#[case(EMPTY, make_buf, check_g1_fail)]
+#[case(EMPTY, make_buf, check_g2_fail)]
+#[case(EMPTY, make_number, check_buf)]
+#[case(EMPTY, make_number, check_number)]
+#[case(EMPTY, make_number, check_g1_fail)]
+#[case(EMPTY, make_number, check_g2_fail)]
+#[case(EMPTY, make_g1_fail, check_buf)]
+#[case(EMPTY, make_g1_fail, check_number)]
+#[case(EMPTY, make_g1_fail, check_g1_fail)]
+#[case(EMPTY, make_g1_fail, check_g2_fail)]
+#[case(EMPTY, make_g2_fail, check_buf)]
+#[case(EMPTY, make_g2_fail, check_number)]
+#[case(EMPTY, make_g2_fail, check_g1_fail)]
+#[case(EMPTY, make_g2_fail, check_g2_fail)]
+// round trip small buffer
+#[case(SMALL_BUF, make_buf, check_buf)]
+#[case(SMALL_BUF, make_buf, check_number)]
+#[case(SMALL_BUF, make_buf, check_g1_fail)]
+#[case(SMALL_BUF, make_buf, check_g2_fail)]
+#[case(SMALL_BUF, make_number, check_buf)]
+#[case(SMALL_BUF, make_number, check_number)]
+#[case(SMALL_BUF, make_number, check_g1_fail)]
+#[case(SMALL_BUF, make_number, check_g2_fail)]
+#[case(SMALL_BUF, make_g1_fail, check_buf)]
+#[case(SMALL_BUF, make_g1_fail, check_number)]
+#[case(SMALL_BUF, make_g1_fail, check_g1_fail)]
+#[case(SMALL_BUF, make_g1_fail, check_g2_fail)]
+#[case(SMALL_BUF, make_g2_fail, check_buf)]
+#[case(SMALL_BUF, make_g2_fail, check_number)]
+#[case(SMALL_BUF, make_g2_fail, check_g1_fail)]
+#[case(SMALL_BUF, make_g2_fail, check_g2_fail)]
+// round trip G1 point
+#[case(VALID_G1, make_buf, check_buf)]
+#[case(VALID_G1, make_buf, check_number)]
+#[case(VALID_G1, make_buf, check_g1)]
+#[case(VALID_G1, make_buf, check_g2_fail)]
+#[case(VALID_G1, make_number, check_buf)]
+#[case(VALID_G1, make_number, check_number)]
+#[case(VALID_G1, make_number, check_g1)]
+#[case(VALID_G1, make_number, check_g2_fail)]
+#[case(VALID_G1, make_g1, check_buf)]
+#[case(VALID_G1, make_g1, check_number)]
+#[case(VALID_G1, make_g1, check_g1)]
+#[case(VALID_G1, make_g1, check_g2_fail)]
+#[case(VALID_G1, make_g2_fail, check_buf)]
+#[case(VALID_G1, make_g2_fail, check_number)]
+#[case(VALID_G1, make_g2_fail, check_g1)]
+#[case(VALID_G1, make_g2_fail, check_g2_fail)]
+// round trip G2 point
+#[case(VALID_G2, make_buf, check_buf)]
+#[case(VALID_G2, make_buf, check_number)]
+#[case(VALID_G2, make_buf, check_g1_fail)]
+#[case(VALID_G2, make_buf, check_g2)]
+#[case(VALID_G2, make_number, check_buf)]
+#[case(VALID_G2, make_number, check_number)]
+#[case(VALID_G2, make_number, check_g1_fail)]
+#[case(VALID_G2, make_number, check_g2)]
+#[case(VALID_G2, make_g1_fail, check_buf)]
+#[case(VALID_G2, make_g1_fail, check_number)]
+#[case(VALID_G2, make_g1_fail, check_g1_fail)]
+#[case(VALID_G2, make_g1_fail, check_g2)]
+#[case(VALID_G2, make_g2, check_buf)]
+#[case(VALID_G2, make_g2, check_number)]
+#[case(VALID_G2, make_g2, check_g1_fail)]
+#[case(VALID_G2, make_g2, check_g2)]
+fn test_roundtrip(#[case] test_value: &str, #[case] make: MakeFun, #[case] check: CheckFun) {
+    let value = hex::decode(test_value).unwrap();
+    let mut a = Allocator::new();
+    let node = make(&mut a, &value);
+    check(&mut a, node, &value);
 }

--- a/src/bls_ops.rs
+++ b/src/bls_ops.rs
@@ -5,7 +5,7 @@ use crate::op_utils::{
     arg_count, atom, check_arg_count, int_atom, mod_group_order, new_atom_and_cost,
     number_to_scalar, MALLOC_COST_PER_BYTE,
 };
-use crate::reduction::{EvalErr, Reduction, Response};
+use crate::reduction::{Reduction, Response};
 use bls12_381::hash_to_curve::{ExpandMsgXmd, HashToCurve};
 use bls12_381::{multi_miller_loop, G1Affine, G1Projective, G2Affine, G2Prepared, G2Projective};
 use group::Group;
@@ -48,30 +48,6 @@ const BLS_PAIRING_COST_PER_ARG: Cost = 1200000;
 
 const DST_G2: &[u8; 43] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_AUG_";
 
-fn g1_atom(node: Node) -> Result<G1Affine, EvalErr> {
-    let blob = atom(node.clone(), "G1 atom")?;
-    if blob.len() != 48 {
-        return node.err("atom is not G1 size, 48 bytes");
-    }
-
-    match G1Affine::from_compressed(blob.try_into().expect("G1 slice is not 48 bytes")).into() {
-        Some(point) => Ok(point),
-        _ => node.err("atom is not a G1 point"),
-    }
-}
-
-fn g2_atom(node: Node) -> Result<G2Affine, EvalErr> {
-    let blob = atom(node.clone(), "G2 atom")?;
-    if blob.len() != 96 {
-        return node.err("atom is not G2 size, 96 bytes");
-    }
-
-    match G2Affine::from_compressed(blob.try_into().expect("G2 slice is not 96 bytes")).into() {
-        Some(point) => Ok(point),
-        _ => node.err("atom is not a G2 point"),
-    }
-}
-
 pub fn op_bls_g1_subtract(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Response {
     let args = Node::new(a, input);
     let mut cost = BLS_G1_SUBTRACT_BASE_COST;
@@ -79,18 +55,20 @@ pub fn op_bls_g1_subtract(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> 
     let mut total: G1Projective = G1Projective::identity();
     let mut is_first = true;
     for arg in &args {
-        let point = g1_atom(arg)?;
+        let point = a.g1(arg.node)?;
         cost += BLS_G1_SUBTRACT_COST_PER_ARG;
         check_cost(a, cost, max_cost)?;
         if is_first {
-            total = G1Projective::from(point);
+            total = point;
         } else {
             total -= point;
         };
         is_first = false;
     }
-    let total: G1Affine = total.into();
-    new_atom_and_cost(a, cost, &total.to_compressed())
+    Ok(Reduction(
+        cost + 48 * MALLOC_COST_PER_BYTE,
+        a.new_g1(total)?,
+    ))
 }
 
 pub fn op_bls_g1_multiply(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Response {
@@ -100,7 +78,7 @@ pub fn op_bls_g1_multiply(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> 
     let mut cost = BLS_G1_MULTIPLY_BASE_COST;
     check_cost(a, cost, max_cost)?;
 
-    let mut total = G1Projective::from(g1_atom(args.first()?)?);
+    let mut total = a.g1(args.first()?.node)?;
     let args = args.rest()?;
     let (scalar, scalar_len) = int_atom(args.first()?, "g1_multiply")?;
     cost += scalar_len as Cost * BLS_G1_MULTIPLY_COST_PER_BYTE;
@@ -108,8 +86,10 @@ pub fn op_bls_g1_multiply(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> 
 
     total *= number_to_scalar(mod_group_order(scalar));
 
-    let total: G1Affine = total.into();
-    new_atom_and_cost(a, cost, &total.to_compressed())
+    Ok(Reduction(
+        cost + 48 * MALLOC_COST_PER_BYTE,
+        a.new_g1(total)?,
+    ))
 }
 
 pub fn op_bls_g1_negate(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
@@ -143,13 +123,15 @@ pub fn op_bls_g2_add(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Respo
     check_cost(a, cost, max_cost)?;
     let mut total: G2Projective = G2Projective::identity();
     for arg in &args {
-        let point = g2_atom(arg)?;
+        let point = a.g2(arg.node)?;
         cost += BLS_G2_ADD_COST_PER_ARG;
         check_cost(a, cost, max_cost)?;
         total += &point;
     }
-    let total: G2Affine = total.into();
-    new_atom_and_cost(a, cost, &total.to_compressed())
+    Ok(Reduction(
+        cost + 96 * MALLOC_COST_PER_BYTE,
+        a.new_g2(total)?,
+    ))
 }
 
 pub fn op_bls_g2_subtract(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Response {
@@ -159,18 +141,20 @@ pub fn op_bls_g2_subtract(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> 
     let mut total: G2Projective = G2Projective::identity();
     let mut is_first = true;
     for arg in &args {
-        let point = g2_atom(arg)?;
+        let point = a.g2(arg.node)?;
         cost += BLS_G2_SUBTRACT_COST_PER_ARG;
         check_cost(a, cost, max_cost)?;
         if is_first {
-            total = G2Projective::from(point);
+            total = point;
         } else {
             total -= point;
         };
         is_first = false;
     }
-    let total: G2Affine = total.into();
-    new_atom_and_cost(a, cost, &total.to_compressed())
+    Ok(Reduction(
+        cost + 96 * MALLOC_COST_PER_BYTE,
+        a.new_g2(total)?,
+    ))
 }
 
 pub fn op_bls_g2_multiply(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Response {
@@ -180,7 +164,7 @@ pub fn op_bls_g2_multiply(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> 
     let mut cost = BLS_G2_MULTIPLY_BASE_COST;
     check_cost(a, cost, max_cost)?;
 
-    let mut total = G2Projective::from(g2_atom(args.first()?)?);
+    let mut total = a.g2(args.first()?.node)?;
     let args = args.rest()?;
     let (scalar, scalar_len) = int_atom(args.first()?, "g2_multiply")?;
     cost += scalar_len as Cost * BLS_G2_MULTIPLY_COST_PER_BYTE;
@@ -188,8 +172,10 @@ pub fn op_bls_g2_multiply(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> 
 
     total *= number_to_scalar(mod_group_order(scalar));
 
-    let total: G2Affine = total.into();
-    new_atom_and_cost(a, cost, &total.to_compressed())
+    Ok(Reduction(
+        cost + 96 * MALLOC_COST_PER_BYTE,
+        a.new_g2(total)?,
+    ))
 }
 
 pub fn op_bls_g2_negate(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
@@ -241,7 +227,10 @@ pub fn op_bls_map_to_g1(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Re
     check_cost(a, cost, max_cost)?;
 
     let point = <G1Projective as HashToCurve<ExpandMsgXmd<sha2::Sha256>>>::hash_to_curve(msg, dst);
-    new_atom_and_cost(a, cost, &G1Affine::from(point).to_compressed())
+    Ok(Reduction(
+        cost + 48 * MALLOC_COST_PER_BYTE,
+        a.new_g1(point)?,
+    ))
 }
 
 pub fn op_bls_map_to_g2(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Response {
@@ -267,7 +256,10 @@ pub fn op_bls_map_to_g2(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Re
     check_cost(a, cost, max_cost)?;
 
     let point = <G2Projective as HashToCurve<ExpandMsgXmd<sha2::Sha256>>>::hash_to_curve(msg, dst);
-    new_atom_and_cost(a, cost, &G2Affine::from(point).to_compressed())
+    Ok(Reduction(
+        cost + 96 * MALLOC_COST_PER_BYTE,
+        a.new_g2(point)?,
+    ))
 }
 
 // This operator takes a variable number of G1 and G2 points. The points must
@@ -285,11 +277,11 @@ pub fn op_bls_pairing_identity(a: &mut Allocator, input: NodePtr, max_cost: Cost
     while !args.nullp() {
         cost += BLS_PAIRING_COST_PER_ARG;
         check_cost(a, cost, max_cost)?;
-        let g1 = g1_atom(args.first()?)?;
+        let g1 = a.g1(args.first()?.node)?;
         args = args.rest()?;
-        let g2 = g2_atom(args.first()?)?;
+        let g2 = a.g2(args.first()?.node)?;
         args = args.rest()?;
-        items.push((g1, G2Prepared::from(g2)));
+        items.push((g1.into(), G2Prepared::from(G2Affine::from(g2))));
     }
 
     let mut item_refs = Vec::<(&G1Affine, &G2Prepared)>::new();
@@ -318,14 +310,14 @@ pub fn op_bls_verify(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Respo
     let args = Node::new(a, input);
 
     // the first argument is the signature
-    let signature = g2_atom(args.first()?)?;
+    let signature = a.g2(args.first()?.node)?;
 
     // followed by a variable number of (G1, msg)-pairs (as a flat list)
     let mut args = args.rest()?;
 
     let mut items = Vec::<(G1Affine, G2Prepared)>::new();
     while !args.nullp() {
-        let pk = g1_atom(args.first()?)?;
+        let pk = a.g1(args.first()?.node)?;
         args = args.rest()?;
         let msg = atom(args.first()?, "bls_verify message")?;
         args = args.rest()?;
@@ -337,17 +329,20 @@ pub fn op_bls_verify(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Respo
 
         // The AUG scheme requires prepending the public key to the signed
         // message
-        let mut prepended_msg = pk.to_compressed().to_vec();
+        let mut prepended_msg = G1Affine::from(pk).to_compressed().to_vec();
         prepended_msg.extend_from_slice(msg);
 
         let point = <G2Projective as HashToCurve<ExpandMsgXmd<sha2::Sha256>>>::hash_to_curve(
             prepended_msg,
             DST_G2,
         );
-        items.push((pk, G2Prepared::from(G2Affine::from(point))));
+        items.push((pk.into(), G2Prepared::from(G2Affine::from(point))));
     }
 
-    items.push((G1Affine::generator().neg(), G2Prepared::from(signature)));
+    items.push((
+        G1Affine::generator().neg(),
+        G2Prepared::from(G2Affine::from(signature)),
+    ));
 
     let mut item_refs = Vec::<(&G1Affine, &G2Prepared)>::new();
     for (p, q) in &items {
@@ -362,78 +357,4 @@ pub fn op_bls_verify(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Respo
     } else {
         Ok(Reduction(cost, a.null()))
     }
-}
-
-// TESTS
-
-#[cfg(test)]
-use rstest::rstest;
-
-#[cfg(test)]
-fn test_g1(n: &Node) -> EvalErr {
-    g1_atom(n.clone()).unwrap_err()
-}
-
-#[cfg(test)]
-fn test_g2(n: &Node) -> EvalErr {
-    g2_atom(n.clone()).unwrap_err()
-}
-
-#[cfg(test)]
-type TestFun = fn(&Node<'_>) -> EvalErr;
-
-#[cfg(test)]
-#[rstest]
-#[case(test_g1, 0, "atom is not G1 size, 48 bytes")]
-#[case(test_g1, 3, "atom is not G1 size, 48 bytes")]
-#[case(test_g1, 47, "atom is not G1 size, 48 bytes")]
-#[case(test_g1, 49, "atom is not G1 size, 48 bytes")]
-#[case(test_g1, 48, "atom is not a G1 point")]
-#[case(test_g2, 0, "atom is not G2 size, 96 bytes")]
-#[case(test_g2, 3, "atom is not G2 size, 96 bytes")]
-#[case(test_g2, 95, "atom is not G2 size, 96 bytes")]
-#[case(test_g2, 97, "atom is not G2 size, 96 bytes")]
-#[case(test_g2, 96, "atom is not a G2 point")]
-fn test_point_atom(#[case] fun: TestFun, #[case] size: usize, #[case] expected: &str) {
-    let mut a = Allocator::new();
-    let mut buf = Vec::<u8>::new();
-    buf.resize(size, 0xcc);
-    let n = a.new_atom(&buf).unwrap();
-    let r = fun(&Node::new(&mut a, n));
-    assert_eq!(r.0, n);
-    assert_eq!(r.1, expected.to_string());
-}
-
-#[cfg(test)]
-#[rstest]
-#[case(test_g1, "G1 atom on list")]
-#[case(test_g2, "G2 atom on list")]
-fn test_point_atom_pair(#[case] fun: TestFun, #[case] expected: &str) {
-    let mut a = Allocator::new();
-    let n = a.new_pair(a.null(), a.one()).unwrap();
-    let r = fun(&Node::new(&mut a, n));
-    assert_eq!(r.0, n);
-    assert_eq!(r.1, expected.to_string());
-}
-
-#[cfg(test)]
-#[rstest]
-#[case("97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb")]
-#[case("a572cbea904d67468808c8eb50a9450c9721db309128012543902d0ac358a62ae28f75bb8f1c7c42c39a8c5529bf0f4e")]
-fn test_g1_atom(#[case] atom: &str) {
-    let mut a = Allocator::new();
-    let n = a.new_atom(&hex::decode(atom).unwrap()).unwrap();
-    let g1 = g1_atom(Node::new(&mut a, n)).unwrap();
-    assert_eq!(hex::encode(g1.to_compressed()), atom);
-}
-
-#[cfg(test)]
-#[rstest]
-#[case("93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8")]
-#[case("aa4edef9c1ed7f729f520e47730a124fd70662a904ba1074728114d1031e1572c6c886f6b57ec72a6178288c47c335771638533957d540a9d2370f17cc7ed5863bc0b995b8825e0ee1ea1e1e4d00dbae81f14b0bf3611b78c952aacab827a053")]
-fn test_g2_atom(#[case] atom: &str) {
-    let mut a = Allocator::new();
-    let n = a.new_atom(&hex::decode(atom).unwrap()).unwrap();
-    let g2 = g2_atom(Node::new(&mut a, n)).unwrap();
-    assert_eq!(hex::encode(g2.to_compressed()), atom);
 }

--- a/src/more_ops.rs
+++ b/src/more_ops.rs
@@ -775,9 +775,10 @@ pub fn op_pubkey_for_exp(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> 
     let cost = PUBKEY_BASE_COST + (v0_len as Cost) * PUBKEY_COST_PER_BYTE;
     let exp: Scalar = number_to_scalar(exp);
     let point: G1Projective = G1Affine::generator() * exp;
-    let point: G1Affine = point.into();
-
-    new_atom_and_cost(a, cost, &point.to_compressed())
+    Ok(Reduction(
+        cost + 48 * MALLOC_COST_PER_BYTE,
+        a.new_g1(point)?,
+    ))
 }
 
 pub fn op_point_add(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Response {
@@ -803,8 +804,10 @@ pub fn op_point_add(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Respon
             return args.err(&msg);
         }
     }
-    let total: G1Affine = total.into();
-    new_atom_and_cost(a, cost, &total.to_compressed())
+    Ok(Reduction(
+        cost + 48 * MALLOC_COST_PER_BYTE,
+        a.new_g1(total)?,
+    ))
 }
 
 pub fn op_coinid(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {


### PR DESCRIPTION
To prepare for a more efficient allocator, where the internal representation can be preserved across CLVM calls.

Is it correct to keep `G1Projective` and `G2Projective` as the internal representation?

note that `g1_negate` and `g2_negate` are not changed. They still operate on byte buffers. Maybe that should change.