### PR TITLE
remove the option to LIMIT_STACK

### DIFF
--- a/fuzz/fuzz_targets/run_program.rs
+++ b/fuzz/fuzz_targets/run_program.rs
@@ -3,8 +3,8 @@ use libfuzzer_sys::fuzz_target;
 
 use clvmr::allocator::Allocator;
 use clvmr::chia_dialect::{
-    ChiaDialect, ENABLE_BLS_OPS, ENABLE_BLS_OPS_OUTSIDE_GUARD, LIMIT_HEAP, LIMIT_STACK,
-    MEMPOOL_MODE, NO_UNKNOWN_OPS,
+    ChiaDialect, ENABLE_BLS_OPS, ENABLE_BLS_OPS_OUTSIDE_GUARD, LIMIT_HEAP, MEMPOOL_MODE,
+    NO_UNKNOWN_OPS,
 };
 use clvmr::cost::Cost;
 use clvmr::reduction::Reduction;
@@ -27,7 +27,6 @@ fuzz_target!(|data: &[u8]| {
         0,
         NO_UNKNOWN_OPS,
         LIMIT_HEAP,
-        LIMIT_STACK,
         ENABLE_BLS_OPS,
         ENABLE_BLS_OPS_OUTSIDE_GUARD,
         MEMPOOL_MODE,

--- a/src/chia_dialect.rs
+++ b/src/chia_dialect.rs
@@ -23,9 +23,6 @@ pub const NO_UNKNOWN_OPS: u32 = 0x0002;
 // the number of pairs
 pub const LIMIT_HEAP: u32 = 0x0004;
 
-// When set, enforce a stack size limit for CLVM programs
-pub const LIMIT_STACK: u32 = 0x0008;
-
 // When set, we allow softfork with extension 0 (which includes coinid and the
 // BLS operators). This remains disabled until the soft-fork activates
 pub const ENABLE_BLS_OPS: u32 = 0x0010;
@@ -36,7 +33,7 @@ pub const ENABLE_BLS_OPS_OUTSIDE_GUARD: u32 = 0x0020;
 
 // The default mode when running grnerators in mempool-mode (i.e. the stricter
 // mode)
-pub const MEMPOOL_MODE: u32 = NO_UNKNOWN_OPS | LIMIT_HEAP | LIMIT_STACK;
+pub const MEMPOOL_MODE: u32 = NO_UNKNOWN_OPS | LIMIT_HEAP;
 
 fn unknown_operator(
     allocator: &mut Allocator,
@@ -174,14 +171,6 @@ impl Dialect for ChiaDialect {
             }
             // new extensions go here
             _ => OperatorSet::Default,
-        }
-    }
-
-    fn stack_limit(&self) -> usize {
-        if (self.flags & LIMIT_STACK) != 0 {
-            20000000
-        } else {
-            usize::MAX
         }
     }
 

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -22,6 +22,5 @@ pub trait Dialect {
         max_cost: Cost,
         extensions: OperatorSet,
     ) -> Response;
-    fn stack_limit(&self) -> usize;
     fn allow_unknown_ops(&self) -> bool;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,7 @@ pub use chia_dialect::ChiaDialect;
 pub use run_program::run_program;
 
 pub use chia_dialect::{
-    ENABLE_BLS_OPS, ENABLE_BLS_OPS_OUTSIDE_GUARD, LIMIT_HEAP, LIMIT_STACK, MEMPOOL_MODE,
-    NO_UNKNOWN_OPS,
+    ENABLE_BLS_OPS, ENABLE_BLS_OPS_OUTSIDE_GUARD, LIMIT_HEAP, MEMPOOL_MODE, NO_UNKNOWN_OPS,
 };
 
 #[cfg(feature = "counters")]

--- a/src/runtime_dialect.rs
+++ b/src/runtime_dialect.rs
@@ -71,10 +71,6 @@ impl Dialect for RuntimeDialect {
         OperatorSet::Default
     }
 
-    fn stack_limit(&self) -> usize {
-        usize::MAX
-    }
-
     fn allow_unknown_ops(&self) -> bool {
         (self.flags & NO_UNKNOWN_OPS) == 0
     }

--- a/wheel/python/clvm_rs/clvm_rs.pyi
+++ b/wheel/python/clvm_rs/clvm_rs.pyi
@@ -13,7 +13,6 @@ def serialized_length(blob: bytes) -> int: ...
 NO_NEG_DIV: int
 NO_UNKNOWN_OPS: int
 LIMIT_HEAP: int
-LIMIT_STACK: int
 MEMPOOL_MODE: int
 
 class LazyNode(CLVMStorage):

--- a/wheel/src/api.rs
+++ b/wheel/src/api.rs
@@ -8,7 +8,7 @@ use clvmr::cost::Cost;
 use clvmr::reduction::Response;
 use clvmr::run_program::run_program;
 use clvmr::serde::{node_from_bytes, parse_triples, serialized_length_from_bytes, ParsedTriple};
-use clvmr::{LIMIT_HEAP, LIMIT_STACK, MEMPOOL_MODE, NO_UNKNOWN_OPS};
+use clvmr::{LIMIT_HEAP, MEMPOOL_MODE, NO_UNKNOWN_OPS};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyTuple};
 use pyo3::wrap_pyfunction;
@@ -79,7 +79,6 @@ fn clvm_rs(_py: Python, m: &PyModule) -> PyResult<()> {
 
     m.add("NO_UNKNOWN_OPS", NO_UNKNOWN_OPS)?;
     m.add("LIMIT_HEAP", LIMIT_HEAP)?;
-    m.add("LIMIT_STACK", LIMIT_STACK)?;
     m.add("MEMPOOL_MODE", MEMPOOL_MODE)?;
     m.add_class::<LazyNode>()?;
 


### PR DESCRIPTION
This softfork has activated and can now be enabled unconditionally.
The main purpose is to simplify the code. Along with this change we also no longer need to pass the `LIMIT_STACK` flag when invoking the interpreter from `chia-blockchain`