### PR TITLE
make AtomBuf private, raise abstraction level of Allocator

### DIFF
--- a/src/more_ops.rs
+++ b/src/more_ops.rs
@@ -523,7 +523,7 @@ pub fn op_concat(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Response 
         )?;
         match arg.sexp() {
             SExp::Pair(_, _) => return arg.err("concat on list"),
-            SExp::Atom(b) => total_size += b.len(),
+            SExp::Atom() => total_size += arg.len(),
         };
         terms.push(arg.node);
     }

--- a/src/node.rs
+++ b/src/node.rs
@@ -15,13 +15,21 @@ impl<'a> Node<'a> {
         Node::new(self.allocator, node)
     }
 
+    pub fn len(&self) -> usize {
+        self.allocator.atom_len(self.node)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.allocator.atom_len(self.node) == 0
+    }
+
     pub fn sexp(&self) -> SExp {
         self.allocator.sexp(self.node)
     }
 
     pub fn atom(&self) -> Option<&'a [u8]> {
         match self.sexp() {
-            SExp::Atom(_) => Some(self.allocator.atom(self.node)),
+            SExp::Atom() => Some(self.allocator.atom(self.node)),
             _ => None,
         }
     }
@@ -35,7 +43,7 @@ impl<'a> Node<'a> {
 
     pub fn nullp(&self) -> bool {
         match self.sexp() {
-            SExp::Atom(a) => a.is_empty(),
+            SExp::Atom() => self.is_empty(),
             _ => false,
         }
     }
@@ -88,7 +96,7 @@ impl<'a> fmt::Debug for Node<'a> {
                 .field(&self.with_node(l))
                 .field(&self.with_node(r))
                 .finish(),
-            SExp::Atom(a) => self.allocator.buf(&a).fmt(f),
+            SExp::Atom() => self.allocator.atom(self.node).fmt(f),
         }
     }
 }

--- a/src/op_utils.rs
+++ b/src/op_utils.rs
@@ -79,7 +79,7 @@ fn test_arg_count() {
 
 pub fn int_atom(args: Node, op_name: &str) -> Result<(Number, usize), EvalErr> {
     match args.sexp() {
-        Atom(_) => Ok((
+        Atom() => Ok((
             args.allocator.number(args.node),
             args.allocator.atom_len(args.node),
         )),
@@ -89,7 +89,7 @@ pub fn int_atom(args: Node, op_name: &str) -> Result<(Number, usize), EvalErr> {
 
 pub fn atom_len(args: Node, op_name: &str) -> Result<usize, EvalErr> {
     match args.sexp() {
-        Atom(_) => Ok(args.allocator.atom_len(args.node)),
+        Atom() => Ok(args.allocator.atom_len(args.node)),
         _ => args.err(&format!("{op_name} requires an atom")),
     }
 }

--- a/src/serde/object_cache.rs
+++ b/src/serde/object_cache.rs
@@ -121,7 +121,7 @@ pub fn treehash(
                 .get_from_cache(&right)
                 .map(|right_value| hash_blobs(&[&[2], left_value, right_value])),
         },
-        SExp::Atom(atom_buf) => Some(hash_blobs(&[&[1], allocator.buf(&atom_buf)])),
+        SExp::Atom() => Some(hash_blobs(&[&[1], allocator.atom(node)])),
     }
 }
 
@@ -142,9 +142,9 @@ pub fn serialized_length(
                     .saturating_add(*right_value)
             }),
         },
-        SExp::Atom(atom_buf) => {
-            let buf = allocator.buf(&atom_buf);
-            let lb: u64 = atom_buf.len().try_into().unwrap_or(u64::MAX);
+        SExp::Atom() => {
+            let buf = allocator.atom(node);
+            let lb: u64 = buf.len().try_into().unwrap_or(u64::MAX);
             Some(if lb == 0 || (lb == 1 && buf[0] < 128) {
                 1
             } else if lb < 0x40 {
@@ -192,7 +192,7 @@ fn calculate_depth_simple(
                 .get_from_cache(&right)
                 .map(|right_value| 1 + max(*left_value, *right_value)),
         },
-        SExp::Atom(_atom_buf) => Some(0),
+        SExp::Atom() => Some(0),
     }
 }
 

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -45,9 +45,8 @@ pub fn node_to_stream<W: io::Write>(node: &Node, f: &mut W) -> io::Result<()> {
     while let Some(v) = values.pop() {
         let n = a.sexp(v);
         match n {
-            SExp::Atom(atom_ptr) => {
-                let atom = a.buf(&atom_ptr);
-                write_atom(f, atom)?;
+            SExp::Atom() => {
+                write_atom(f, a.atom(v))?;
             }
             SExp::Pair(left, right) => {
                 f.write_all(&[CONS_BOX_MARKER])?;

--- a/src/serde/ser_br.rs
+++ b/src/serde/ser_br.rs
@@ -60,8 +60,8 @@ pub fn node_to_stream_backrefs<W: io::Write>(node: &Node, f: &mut W) -> io::Resu
                     read_op_stack.push(ReadOp::Parse);
                     read_op_stack.push(ReadOp::Parse);
                 }
-                SExp::Atom(atom_buf) => {
-                    let atom = allocator.buf(&atom_buf);
+                SExp::Atom() => {
+                    let atom = allocator.atom(node_to_write);
                     write_atom(f, atom)?;
                     read_cache_lookup.push(*node_tree_hash);
                 }

--- a/src/test_ops.rs
+++ b/src/test_ops.rs
@@ -179,8 +179,8 @@ pub fn node_eq(a: &Allocator, a0: NodePtr, a1: NodePtr) -> bool {
                 false
             }
         }
-        SExp::Atom(_) => {
-            if let SExp::Atom(_) = a.sexp(a1) {
+        SExp::Atom() => {
+            if let SExp::Atom() = a.sexp(a1) {
                 a.atom(a0) == a.atom(a1)
             } else {
                 false
@@ -363,9 +363,9 @@ fn equal_sexp(allocator: &Allocator, s1: NodePtr, s2: NodePtr) -> bool {
         (SExp::Pair(s1a, s1b), SExp::Pair(s2a, s2b)) => {
             equal_sexp(allocator, s1a, s2a) && equal_sexp(allocator, s1b, s2b)
         }
-        (SExp::Atom(b1), SExp::Atom(b2)) => {
-            let abuf1 = allocator.buf(&b1);
-            let abuf2 = allocator.buf(&b2);
+        (SExp::Atom(), SExp::Atom()) => {
+            let abuf1 = allocator.atom(s1);
+            let abuf2 = allocator.atom(s2);
             abuf1 == abuf2
         }
         _ => false,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,7 +9,9 @@ impl<'a> PartialEq for Node<'a> {
             (SExp::Pair(l0, l1), SExp::Pair(r0, r1)) => {
                 self.with_node(l0) == self.with_node(r0) && self.with_node(l1) == self.with_node(r1)
             }
-            (SExp::Atom(l0), SExp::Atom(r0)) => self.allocator.buf(&l0) == self.allocator.buf(&r0),
+            (SExp::Atom(), SExp::Atom()) => {
+                self.allocator.atom(self.node) == self.allocator.atom(other.node)
+            }
             _ => false,
         }
     }

--- a/src/traverse_path.rs
+++ b/src/traverse_path.rs
@@ -54,7 +54,7 @@ pub fn traverse_path(allocator: &Allocator, node_index: &[u8], args: NodePtr) ->
     while byte_idx > first_bit_byte_index || bitmask < last_bitmask {
         let is_bit_set: bool = (node_index[byte_idx] & bitmask) != 0;
         match allocator.sexp(arg_list) {
-            SExp::Atom(_) => {
+            SExp::Atom() => {
                 return Err(EvalErr(arg_list, "path into atom".into()));
             }
             SExp::Pair(left, right) => {

--- a/wasm/src/lazy_node.rs
+++ b/wasm/src/lazy_node.rs
@@ -31,7 +31,7 @@ impl LazyNode {
     #[wasm_bindgen(getter)]
     pub fn atom(&self) -> Option<Vec<u8>> {
         match &self.allocator.sexp(self.node) {
-            SExp::Atom(atom) => Some(self.allocator.buf(atom).into()),
+            SExp::Atom() => Some(self.allocator.atom(self.node).into()),
             _ => None,
         }
     }

--- a/wheel/src/lazy_node.rs
+++ b/wheel/src/lazy_node.rs
@@ -37,7 +37,7 @@ impl LazyNode {
     #[getter(atom)]
     pub fn atom(&self, py: Python) -> Option<PyObject> {
         match &self.allocator.sexp(self.node) {
-            SExp::Atom(atom) => Some(PyBytes::new(py, self.allocator.buf(atom)).into()),
+            SExp::Atom() => Some(PyBytes::new(py, self.allocator.atom(self.node)).into()),
             _ => None,
         }
     }


### PR DESCRIPTION
Not exposing offsets into the internal heap affords the allocator more freedom in its internal data structure.
This is a step towards preserving internal representations of `Number`, G1 and G2 points.