### PR TITLE
fix benchmark operators

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -236,6 +236,9 @@ jobs:
             toolchain: stable
             components: rustfmt, clippy
 
+      - name: build
+        run: cargo build --workspace
+
       - name: cargo test (default)
         run: cargo test && cargo test --release
 

--- a/docs/new-operator-checklist.md
+++ b/docs/new-operator-checklist.md
@@ -23,6 +23,8 @@ Follow this checklist when adding operators:
 * Include the new operators in the fuzzer `fuzz/fuzz_targets/operators.rs`
 * Include the new operators and their signatures in `tools/src/bin/generate-fuzz-corpus.rs`.
   Make sure to run this and fuzz for some time before landing the PR.
+* extend the benchmark-clvm-cost.rs to include benchmarks for the new operator,
+  to establish its cost.
 * The opcode decoding and dispatching happens in `src/ChiaDialect.rs`
 * Add a new flag (in `src/chia_dialect.rs`) that controls whether the
   operators are activated or not. This is required in order for the chain to exist

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -248,7 +248,7 @@ impl Allocator {
 
     pub fn g1(&self, node: NodePtr) -> Result<G1Projective, EvalErr> {
         let blob = match self.sexp(node) {
-            SExp::Atom(buf) => self.buf(&buf),
+            SExp::Atom() => self.atom(node),
             _ => {
                 return err(node, "pair found, expected G1 point");
             }
@@ -267,7 +267,7 @@ impl Allocator {
 
     pub fn g2(&self, node: NodePtr) -> Result<G2Projective, EvalErr> {
         let blob = match self.sexp(node) {
-            SExp::Atom(buf) => self.buf(&buf),
+            SExp::Atom() => self.atom(node),
             _ => {
                 return err(node, "pair found, expected G2 point");
             }

--- a/tools/src/bin/benchmark-clvm-cost.rs
+++ b/tools/src/bin/benchmark-clvm-cost.rs
@@ -104,7 +104,7 @@ fn time_per_byte(a: &mut Allocator, op: u32, extra: Option<NodePtr>) -> f64 {
         let op_code = a.new_number(op.into()).unwrap();
         let call = a.new_pair(op_code, args).unwrap();
         let start = Instant::now();
-        let _ = run_program(a, &dialect, call, a.null(), 11000000000).unwrap();
+        let _ = run_program(a, &dialect, call, a.null(), 11000000000);
         let duration = start.elapsed();
         samples.push((i as f64, duration.as_nanos() as f64));
         a.restore_checkpoint(&checkpoint);


### PR DESCRIPTION
The tool to benchmark operators to establish cost has already bitrotted. This clean ups some of the hacks in there as well as makes it work again.

This also prepares this tool for being extended to secp operators.

Each commit can be reviewed independently.