### PR TITLE
Option to fix div

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@ pub use chia_dialect::ChiaDialect;
 pub use run_program::run_program;
 
 pub use chia_dialect::{
-    ENABLE_BLS_OPS, ENABLE_BLS_OPS_OUTSIDE_GUARD, ENABLE_SECP_OPS, LIMIT_HEAP, MEMPOOL_MODE,
-    NO_UNKNOWN_OPS,
+    ENABLE_BLS_OPS, ENABLE_BLS_OPS_OUTSIDE_GUARD, ENABLE_FIXED_DIV, ENABLE_SECP_OPS, LIMIT_HEAP,
+    MEMPOOL_MODE, NO_UNKNOWN_OPS,
 };
 
 #[cfg(feature = "counters")]

--- a/src/more_ops.rs
+++ b/src/more_ops.rs
@@ -431,6 +431,19 @@ pub fn op_div(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     }
 }
 
+pub fn op_div_fixed(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
+    let args = Node::new(a, input);
+    let (a0, l0, a1, l1) = two_ints(&args, "/")?;
+    let cost = DIV_BASE_COST + ((l0 + l1) as Cost) * DIV_COST_PER_BYTE;
+    if a1.sign() == Sign::NoSign {
+        args.first()?.err("div with 0")
+    } else {
+        let q = a0.div_floor(&a1);
+        let q = a.new_number(q)?;
+        Ok(malloc_cost(a, cost, q))
+    }
+}
+
 pub fn op_divmod(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     let args = Node::new(a, input);
     let (a0, l0, a1, l1) = two_ints(&args, "divmod")?;

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -565,16 +565,52 @@ struct RunProgramTest {
 use crate::test_ops::parse_exp;
 
 #[cfg(test)]
-use crate::chia_dialect::ENABLE_BLS_OPS;
-#[cfg(test)]
-use crate::chia_dialect::ENABLE_BLS_OPS_OUTSIDE_GUARD;
-#[cfg(test)]
-use crate::chia_dialect::ENABLE_SECP_OPS;
-#[cfg(test)]
-use crate::chia_dialect::NO_UNKNOWN_OPS;
+use crate::chia_dialect::{
+    ENABLE_BLS_OPS, ENABLE_BLS_OPS_OUTSIDE_GUARD, ENABLE_FIXED_DIV, ENABLE_SECP_OPS, NO_UNKNOWN_OPS,
+};
 
 #[cfg(test)]
 const TEST_CASES: &[RunProgramTest] = &[
+    RunProgramTest {
+        prg: "(/ (q . 10) (q . -3))",
+        args: "()",
+        flags: 0,
+        result: None,
+        cost: 0,
+        err: "div operator with negative operands is deprecated",
+    },
+    RunProgramTest {
+        prg: "(/ (q . -10) (q . 3))",
+        args: "()",
+        flags: 0,
+        result: None,
+        cost: 0,
+        err: "div operator with negative operands is deprecated",
+    },
+    RunProgramTest {
+        prg: "(/ (q . 10) (q . -3))",
+        args: "()",
+        flags: ENABLE_FIXED_DIV,
+        result: Some("-4"),
+        cost: 1047,
+        err: "",
+    },
+    RunProgramTest {
+        prg: "(/ (q . -10) (q . 3))",
+        args: "()",
+        flags: ENABLE_FIXED_DIV,
+        result: Some("-4"),
+        cost: 1047,
+        err: "",
+    },
+    RunProgramTest {
+        prg: "(/ (q . -1) (q . 2))",
+        args: "()",
+        flags: ENABLE_FIXED_DIV,
+        result: Some("-1"),
+        cost: 1047,
+        err: "",
+    },
     // (mod (X N) (defun power (X N) (if (= N 0) 1 (* X (power X (- N 1))))) (power X N))
     RunProgramTest {
         prg: "(a (q 2 2 (c 2 (c 5 (c 11 ())))) (c (q 2 (i (= 11 ()) (q 1 . 1) (q 18 5 (a 2 (c 2 (c 5 (c (- 11 (q . 1)) ())))))) 1) 1))",


### PR DESCRIPTION
This adds a new flag, `ENABLE_FIXED_DIV` which, when set, uses a `div` operator that allows negative numbers.

This is intended for the hard-fork to be introduced by 2.0