### PR TITLE
use NodePtr in serialization

### DIFF
--- a/fuzz/fuzz_targets/deserialize_br.rs
+++ b/fuzz/fuzz_targets/deserialize_br.rs
@@ -1,6 +1,5 @@
 #![no_main]
 use clvmr::allocator::Allocator;
-use clvmr::node::Node;
 use clvmr::serde::node_from_bytes_backrefs;
 use clvmr::serde::node_to_bytes_backrefs;
 use libfuzzer_sys::fuzz_target;
@@ -14,12 +13,12 @@ fuzz_target!(|data: &[u8]| {
         Ok(r) => r,
     };
 
-    let b1 = node_to_bytes_backrefs(&Node::new(&allocator, program)).unwrap();
+    let b1 = node_to_bytes_backrefs(&allocator, program).unwrap();
 
     let mut allocator = Allocator::new();
     let program = node_from_bytes_backrefs(&mut allocator, &b1).unwrap();
 
-    let b2 = node_to_bytes_backrefs(&Node::new(&allocator, program)).unwrap();
+    let b2 = node_to_bytes_backrefs(&allocator, program).unwrap();
     if b1 != b2 {
         panic!("b1 and b2 do not match");
     }

--- a/fuzz/fuzz_targets/deserialize_br_rand_tree.rs
+++ b/fuzz/fuzz_targets/deserialize_br_rand_tree.rs
@@ -3,7 +3,6 @@
 mod fuzzing_utils;
 
 use clvmr::allocator::Allocator;
-use clvmr::node::Node;
 use clvmr::serde::node_from_bytes_backrefs;
 use clvmr::serde::node_to_bytes_backrefs;
 use libfuzzer_sys::fuzz_target;
@@ -15,12 +14,12 @@ fn do_fuzz(data: &[u8], short_atoms: bool) {
 
     let program = fuzzing_utils::make_tree(&mut allocator, &mut cursor, short_atoms);
 
-    let b1 = node_to_bytes_backrefs(&Node::new(&allocator, program)).unwrap();
+    let b1 = node_to_bytes_backrefs(&allocator, program).unwrap();
 
     let mut allocator = Allocator::new();
     let program = node_from_bytes_backrefs(&mut allocator, &b1).unwrap();
 
-    let b2 = node_to_bytes_backrefs(&Node::new(&allocator, program)).unwrap();
+    let b2 = node_to_bytes_backrefs(&allocator, program).unwrap();
     if b1 != b2 {
         panic!("b1 and b2 do not match");
     }

--- a/op-tests/test-core-ops.txt
+++ b/op-tests/test-core-ops.txt
@@ -9,10 +9,12 @@ i 1 1 => FAIL
 i 1 1 1 1 => FAIL
 i 1 "true" "false" => "true" | 33
 i 0 "true" "false" => "false" | 33
-i 0 "true" "false" => "false" | 33
 i "" "true" "false" => "false" | 33
 i 10 "true" "false" => "true" | 33
 i -1 "true" "false" => "true" | 33
+i (1 2) "true" "false" => "true" | 33
+i (1) "true" "false" => "true" | 33
+i () "true" "false" => "false" | 33
 
 ; tests ported from clvm
 i 100 200 300 => 200 | 33

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -83,8 +83,11 @@ struct SoftforkGuard {
     start_cost: Cost,
 }
 
-// `run_program` has two stacks: the operand stack (of `Node` objects) and the
-// operator stack (of Operation)
+// `run_program` has three stacks:
+// 1. the operand stack of `NodePtr` objects. val_stack
+// 2. the operator stack of Operation. op_stack
+// 3. the environment stack (points to the environment for the current
+//    operation). env_stack
 
 struct RunProgramContext<'a, D> {
     allocator: &'a mut Allocator,

--- a/src/serde/test.rs
+++ b/src/serde/test.rs
@@ -18,16 +18,14 @@ fn check_round_trip(obj_ser_br_hex: &str) {
     let mut allocator = Allocator::new();
     let obj = node_from_bytes_backrefs(&mut allocator, &obj_ser_br).unwrap();
 
-    let node = Node::new(&allocator, obj);
-    let obj_ser_no_br_1 = node_to_bytes(&node).unwrap();
+    let obj_ser_no_br_1 = node_to_bytes(&allocator, obj).unwrap();
 
     // deserialize using `node_from_bytes_backrefs` (even though there are no backrefs)
     // and reserialized without back-refs
     let mut allocator = Allocator::new();
     let obj = node_from_bytes_backrefs(&mut allocator, &obj_ser_no_br_1).unwrap();
 
-    let node = Node::new(&allocator, obj);
-    let obj_ser_no_br_2 = node_to_bytes(&node).unwrap();
+    let obj_ser_no_br_2 = node_to_bytes(&allocator, obj).unwrap();
 
     // compare both reserializations (without back-refs)
     assert_eq!(obj_ser_no_br_1, obj_ser_no_br_2);

--- a/src/serde/test.rs
+++ b/src/serde/test.rs
@@ -1,7 +1,6 @@
 use hex::FromHex;
 
 use crate::allocator::Allocator;
-use crate::node::Node;
 
 use crate::serde::de::node_from_bytes;
 use crate::serde::de_br::node_from_bytes_backrefs;
@@ -34,8 +33,7 @@ fn check_round_trip(obj_ser_br_hex: &str) {
     let mut allocator = Allocator::new();
     let obj = node_from_bytes(&mut allocator, &obj_ser_no_br_1).unwrap();
 
-    let node = Node::new(&allocator, obj);
-    let obj_ser_br_1 = node_to_bytes_backrefs(&node).unwrap();
+    let obj_ser_br_1 = node_to_bytes_backrefs(&allocator, obj).unwrap();
 
     // and compare to original
     assert_eq!(obj_ser_br, obj_ser_br_1);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -18,7 +18,7 @@ impl<'a> PartialEq for Node<'a> {
 }
 
 fn test_serialize_roundtrip(a: &mut Allocator, n: NodePtr) {
-    let vec = node_to_bytes(&Node::new(a, n)).unwrap();
+    let vec = node_to_bytes(a, n).unwrap();
     let n0 = node_from_bytes(a, &vec).unwrap();
     let n1 = Node::new(a, n0);
     assert_eq!(Node::new(a, n), n1);
@@ -73,32 +73,26 @@ fn test_serialize_blobs() {
     let mut a = Allocator::new();
 
     // null
-    let n = Node::new(&a, a.null());
-    assert_eq!(node_to_bytes(&n).unwrap(), &[0x80]);
+    let n = a.null();
+    assert_eq!(node_to_bytes(&a, n).unwrap(), &[0x80]);
 
     // one
-    let n = Node::new(&a, a.one());
-    assert_eq!(node_to_bytes(&n).unwrap(), &[1]);
+    let n = a.one();
+    assert_eq!(node_to_bytes(&a, n).unwrap(), &[1]);
 
     // single byte
-    let atom = a.new_atom(&[128]).unwrap();
-    let n = Node::new(&a, atom);
-    assert_eq!(node_to_bytes(&n).unwrap(), &[0x81, 128]);
-    let n = n.node;
+    let n = a.new_atom(&[128]).unwrap();
+    assert_eq!(node_to_bytes(&a, n).unwrap(), &[0x81, 128]);
     test_serialize_roundtrip(&mut a, n);
 
     // two bytes
-    let atom = a.new_atom(&[0x10, 0xff]).unwrap();
-    let n = Node::new(&a, atom);
-    assert_eq!(node_to_bytes(&n).unwrap(), &[0x82, 0x10, 0xff]);
-    let n = n.node;
+    let n = a.new_atom(&[0x10, 0xff]).unwrap();
+    assert_eq!(node_to_bytes(&a, n).unwrap(), &[0x82, 0x10, 0xff]);
     test_serialize_roundtrip(&mut a, n);
 
     // three bytes
-    let atom = a.new_atom(&[0xff, 0x10, 0xff]).unwrap();
-    let n = Node::new(&a, atom);
-    assert_eq!(node_to_bytes(&n).unwrap(), &[0x83, 0xff, 0x10, 0xff]);
-    let n = n.node;
+    let n = a.new_atom(&[0xff, 0x10, 0xff]).unwrap();
+    assert_eq!(node_to_bytes(&a, n).unwrap(), &[0x83, 0xff, 0x10, 0xff]);
     test_serialize_roundtrip(&mut a, n);
 }
 
@@ -108,24 +102,21 @@ fn test_serialize_lists() {
 
     // null
     let n = a.null();
-    assert_eq!(node_to_bytes(&Node::new(&a, n)).unwrap(), &[0x80]);
+    assert_eq!(node_to_bytes(&a, n).unwrap(), &[0x80]);
 
     // one item
     let n = a.new_pair(a.one(), n).unwrap();
-    assert_eq!(node_to_bytes(&Node::new(&a, n)).unwrap(), &[0xff, 1, 0x80]);
+    assert_eq!(node_to_bytes(&a, n).unwrap(), &[0xff, 1, 0x80]);
 
     // two items
     let n = a.new_pair(a.one(), n).unwrap();
-    assert_eq!(
-        node_to_bytes(&Node::new(&a, n)).unwrap(),
-        &[0xff, 1, 0xff, 1, 0x80]
-    );
+    assert_eq!(node_to_bytes(&a, n).unwrap(), &[0xff, 1, 0xff, 1, 0x80]);
     test_serialize_roundtrip(&mut a, n);
 
     // three items
     let n = a.new_pair(a.one(), n).unwrap();
     assert_eq!(
-        node_to_bytes(&Node::new(&a, n)).unwrap(),
+        node_to_bytes(&a, n).unwrap(),
         &[0xff, 1, 0xff, 1, 0xff, 1, 0x80]
     );
     test_serialize_roundtrip(&mut a, n);
@@ -136,7 +127,7 @@ fn test_serialize_lists() {
     let n = a.new_pair(n, a.one()).unwrap();
     let n = a.new_pair(n, a.one()).unwrap();
     assert_eq!(
-        node_to_bytes(&Node::new(&a, n)).unwrap(),
+        node_to_bytes(&a, n).unwrap(),
         &[0xff, 0xff, 0xff, 1, 1, 1, 1]
     );
     test_serialize_roundtrip(&mut a, n);
@@ -154,7 +145,7 @@ fn test_serialize_tree() {
     let r = a.new_pair(a3, a4).unwrap();
     let n = a.new_pair(l, r).unwrap();
     assert_eq!(
-        node_to_bytes(&Node::new(&a, n)).unwrap(),
+        node_to_bytes(&a, n).unwrap(),
         &[0xff, 0xff, 1, 2, 0xff, 3, 4]
     );
     test_serialize_roundtrip(&mut a, n);

--- a/wasm/src/api.rs
+++ b/wasm/src/api.rs
@@ -7,7 +7,6 @@ use clvmr::allocator::Allocator;
 use clvmr::chia_dialect::ChiaDialect;
 use clvmr::chia_dialect::NO_UNKNOWN_OPS as _no_unknown_ops;
 use clvmr::cost::Cost;
-use clvmr::node::Node;
 use clvmr::run_program::run_program;
 use clvmr::serde::{node_from_bytes, node_to_bytes, serialized_length_from_bytes};
 
@@ -52,7 +51,7 @@ pub fn run_clvm(program: &[u8], args: &[u8]) -> Vec<u8> {
         max_cost,
     );
     match r {
-        Ok(reduction) => node_to_bytes(&Node::new(&allocator, reduction.1)).unwrap(),
+        Ok(reduction) => node_to_bytes(&allocator, reduction.1).unwrap(),
         Err(_eval_err) => format!("{:?}", _eval_err).into(),
     }
 }


### PR DESCRIPTION
This PR is best reviewed one commit at a time.

The main change is to make `node_to_bytes()` and `node_to_bytes_backrefs()` take an `&Allocator` and `NodePtr` directly, instead of a `&Node`.

The rationale is two-fold:

1. We want to move towards a future where we don't use `Node`. Wrapping an immutable reference to `Allocator` inside the `Node` object is problematic because it prevents simultaneous mutable references to the allocator. This is especially a problem as we move towards an allocator with lazy conversions, where more operations on it will require mutation.
2. It's a slight simplification of these functions. All they do with the `Node` is to unwrap it into the `&Allocator` and `NodePtr` first thing.

There are also two minor unrelated changes:
1. fixing a comment
2. adding some test cases for the `i` operator