### PR TITLE
Phase out use of `Node`

### DIFF
--- a/src/bls_ops.rs
+++ b/src/bls_ops.rs
@@ -1,5 +1,6 @@
 use crate::allocator::{Allocator, NodePtr};
 use crate::cost::{check_cost, Cost};
+use crate::err_utils::err;
 use crate::node::Node;
 use crate::op_utils::{
     arg_count, atom, check_arg_count, int_atom, mod_group_order, new_atom_and_cost,
@@ -100,7 +101,7 @@ pub fn op_bls_g1_negate(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> R
     // point once the allocator preserves native representation of points
     let blob = atom(args.first()?, "G1 atom")?;
     if blob.len() != 48 {
-        return args.first()?.err("atom is not G1 size, 48 bytes");
+        return err(args.first()?.node, "atom is not G1 size, 48 bytes");
     }
     if (blob[0] & 0xe0) == 0xc0 {
         // This is compressed infinity. negating it is a no-op
@@ -186,7 +187,7 @@ pub fn op_bls_g2_negate(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> R
     // point once the allocator preserves native representation of points
     let blob = atom(args.first()?, "G2 atom")?;
     if blob.len() != 96 {
-        return args.first()?.err("atom is not G2 size, 96 bytes");
+        return err(args.first()?.node, "atom is not G2 size, 96 bytes");
     }
     if (blob[0] & 0xe0) == 0xc0 {
         // This is compressed infinity. negating it is a no-op
@@ -207,7 +208,7 @@ pub fn op_bls_map_to_g1(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Re
     let args = Node::new(a, input);
     let ac = arg_count(&args, 2);
     if !(1..=2).contains(&ac) {
-        return args.err("g_1_map takes exactly 1 or 2 arguments");
+        return err(input, "g_1_map takes exactly 1 or 2 arguments");
     }
     let mut cost: Cost = BLS_MAP_TO_G1_BASE_COST;
     check_cost(a, cost, max_cost)?;
@@ -237,7 +238,7 @@ pub fn op_bls_map_to_g2(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Re
     let args = Node::new(a, input);
     let ac = arg_count(&args, 2);
     if !(1..=2).contains(&ac) {
-        return args.err("g2_map takes exactly 1 or 2 arguments");
+        return err(input, "g2_map takes exactly 1 or 2 arguments");
     }
     let mut cost: Cost = BLS_MAP_TO_G2_BASE_COST;
     check_cost(a, cost, max_cost)?;
@@ -293,7 +294,7 @@ pub fn op_bls_pairing_identity(a: &mut Allocator, input: NodePtr, max_cost: Cost
         .is_identity()
         .into();
     if !identity {
-        Node::new(a, input).err("bls_pairing_identity failed")
+        err(input, "bls_pairing_identity failed")
     } else {
         Ok(Reduction(cost, a.null()))
     }
@@ -353,7 +354,7 @@ pub fn op_bls_verify(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Respo
         .is_identity()
         .into();
     if !identity {
-        Node::new(a, input).err("bls_verify failed")
+        err(input, "bls_verify failed")
     } else {
         Ok(Reduction(cost, a.null()))
     }

--- a/src/core_ops.rs
+++ b/src/core_ops.rs
@@ -1,5 +1,6 @@
 use crate::allocator::{Allocator, NodePtr};
 use crate::cost::Cost;
+use crate::err_utils::err;
 use crate::node::Node;
 use crate::op_utils::{atom, check_arg_count};
 use crate::reduction::{Reduction, Response};
@@ -78,7 +79,7 @@ pub fn op_raise(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response 
         })
         .unwrap_or(args);
 
-    throw_value.err("clvm raise")
+    err(throw_value.node, "clvm raise")
 }
 
 pub fn op_eq(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {

--- a/src/more_ops.rs
+++ b/src/more_ops.rs
@@ -498,11 +498,11 @@ pub fn op_substr(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response
     let s0 = atom(a0.clone(), "substr")?;
     let size = s0.len();
     let rest = args.rest()?;
-    let i1 = i32_atom(&rest.first()?, "substr")?;
+    let i1 = i32_atom(a, rest.first()?.node, "substr")?;
     let rest = rest.rest()?;
 
     let i2 = if ac == 3 {
-        i32_atom(&rest.first()?, "substr")?
+        i32_atom(a, rest.first()?.node, "substr")?
     } else {
         size as i32
     };
@@ -547,7 +547,7 @@ pub fn op_ash(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     check_arg_count(&args, 2, "ash")?;
     let (i0, l0) = int_atom(args.first()?, "ash")?;
     let rest = args.rest()?;
-    let a1 = i32_atom(&rest.first()?, "ash")?;
+    let a1 = i32_atom(a, rest.first()?.node, "ash")?;
     if !(-65535..=65535).contains(&a1) {
         return err(rest.first()?.node, "shift too large");
     }
@@ -623,7 +623,7 @@ pub fn op_lsh(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     let i0 = BigUint::from_bytes_be(b0);
     let l0 = b0.len();
     let rest = args.rest()?;
-    let a1 = i32_atom(&rest.first()?, "lsh")?;
+    let a1 = i32_atom(a, rest.first()?.node, "lsh")?;
     if !(-65535..=65535).contains(&a1) {
         return err(rest.first()?.node, "shift too large");
     }

--- a/src/op_utils.rs
+++ b/src/op_utils.rs
@@ -358,17 +358,17 @@ fn test_u64_from_bytes() {
     );
 }
 
-pub fn i32_atom(args: &Node, op_name: &str) -> Result<i32, EvalErr> {
-    let buf = match args.atom() {
-        Some(a) => a,
+pub fn i32_atom(a: &Allocator, args: NodePtr, op_name: &str) -> Result<i32, EvalErr> {
+    let buf = match a.sexp(args) {
+        SExp::Atom() => a.atom(args),
         _ => {
-            return err(args.node, &format!("{op_name} requires int32 args"));
+            return err(args, &format!("{op_name} requires int32 args"));
         }
     };
     match i32_from_u8(buf) {
         Some(v) => Ok(v),
         _ => err(
-            args.node,
+            args,
             &format!("{op_name} requires int32 args (with no leading zeros)"),
         ),
     }

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -334,9 +334,11 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
         }
         let args = args.rest()?;
 
-        let extension = self
-            .dialect
-            .softfork_extension(uint_atom::<4>(&args.first()?, "softfork")? as u32);
+        let extension = self.dialect.softfork_extension(uint_atom::<4>(
+            self.allocator,
+            args.first()?.node,
+            "softfork",
+        )? as u32);
         if extension == OperatorSet::Default {
             return Err(EvalErr(args.node, "unknown softfork extension".to_string()));
         }
@@ -369,7 +371,8 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
 
             self.eval_pair(new_operator, env).map(|c| c + APPLY_COST)
         } else if op_atom == self.dialect.softfork_kw() {
-            let expected_cost = uint_atom::<8>(&operand_list.first()?, "softfork")?;
+            let expected_cost =
+                uint_atom::<8>(self.allocator, operand_list.first()?.node, "softfork")?;
             if expected_cost > max_cost {
                 return err(self.allocator.null(), "cost exceeded");
             }

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -361,7 +361,7 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
             .ok_or_else(|| EvalErr(operator.node, "runtime error: env stack empty".into()))?;
         if op_atom == self.dialect.apply_kw() {
             if !operand_list.arg_count_is(2) {
-                return operand_list.err("apply requires exactly 2 parameters");
+                return err(operand_list.node, "apply requires exactly 2 parameters");
             }
 
             let new_operator = operand_list.first()?.node;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,4 @@
 use super::allocator::{Allocator, NodePtr, SExp};
-use super::node::Node;
 use super::serde::node_from_bytes;
 use super::serde::node_to_bytes;
 


### PR DESCRIPTION
These 3 commits all move away from using the `Node` abstraction. The commits are independent and are best reviewed one at a time.