### PR TITLE
Swap from podman to docker

### DIFF
--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build_wheels:
-    name: ARM64 Python Wheels on ubuntu-latest
+    name: ARM64 Python Wheels on ARM64 Ubuntu
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -27,17 +27,10 @@ jobs:
       with:
         fetch-depth: 1
 
-    - name: Set up QEMU on x86_64
-      if: startsWith(matrix.os, 'ubuntu-latest')
-      id: qemu
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: arm64
-
     - name: Build Python wheels
       run: |
-        podman run --rm=true \
-          -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+        docker run --rm \
+          -v ${{ github.workspace }}:/ws --workdir=/ws \
           quay.io/pypa/manylinux2014_aarch64 \
           bash -exc '\
             echo $PATH && \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -63,6 +63,8 @@ jobs:
           bash -exc '\
             curl -L https://sh.rustup.rs > rustup-init.sh && \
             sh rustup-init.sh -y && \
+            yum clean all --enablerepo=*; yum update --disablerepo=epel && \
+            yum update && \
             yum -y install openssl-devel && \
             source $HOME/.cargo/env && \
             rustup target add x86_64-unknown-linux-musl && \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -63,9 +63,7 @@ jobs:
           bash -exc '\
             curl -L https://sh.rustup.rs > rustup-init.sh && \
             sh rustup-init.sh -y && \
-            yum clean all --enablerepo=*; yum update --disablerepo=epel && \
-            yum update && \
-            yum -y install openssl-devel && \
+            yum -y --disablerepo=epel install openssl-devel && \
             source $HOME/.cargo/env && \
             rustup target add x86_64-unknown-linux-musl && \
             PY_VERSION=${{ matrix.python }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -57,8 +57,8 @@ jobs:
     - name: Build Linux in manylinux2014 with maturin on Python ${{ matrix.python }}
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        podman run --rm=true \
-          -v ${{ github.workspace }}:/ws:rw --workdir=/ws \
+        docker run --rm \
+          -v ${{ github.workspace }}:/ws --workdir=/ws \
           quay.io/pypa/manylinux2014_x86_64 \
           bash -exc '\
             curl -L https://sh.rustup.rs > rustup-init.sh && \


### PR DESCRIPTION
The repo to get podman installed on 20.04 is problematic. We have docker available though, so swapping podman -> docker to make the runners easier to manage.

Also don't need QEMU on the arm build, since its on a native arm runner.