### PR TITLE
Convert NodePtr to a newtype rather than alias

### DIFF
--- a/src/op_utils.rs
+++ b/src/op_utils.rs
@@ -19,7 +19,7 @@ pub fn get_args<const N: usize>(
 ) -> Result<[NodePtr; N], EvalErr> {
     let mut next = args;
     let mut counter = 0;
-    let mut ret: [NodePtr; N] = [0; N];
+    let mut ret: [NodePtr; N] = [NodePtr(0); N];
 
     while let Some((first, rest)) = a.next(next) {
         next = rest;
@@ -92,7 +92,7 @@ pub fn get_varargs<const N: usize>(
 ) -> Result<([NodePtr; N], usize), EvalErr> {
     let mut next = args;
     let mut counter = 0;
-    let mut ret: [NodePtr; N] = [0; N];
+    let mut ret: [NodePtr; N] = [NodePtr(0); N];
 
     while let Some((first, rest)) = a.next(next) {
         next = rest;
@@ -132,19 +132,19 @@ fn test_get_varargs() {
     );
     assert_eq!(
         get_varargs::<4>(&a, args3, "test").unwrap(),
-        ([a1, a2, a3, 0], 3)
+        ([a1, a2, a3, NodePtr(0)], 3)
     );
     assert_eq!(
         get_varargs::<4>(&a, args2, "test").unwrap(),
-        ([a2, a3, 0, 0], 2)
+        ([a2, a3, NodePtr(0), NodePtr(0)], 2)
     );
     assert_eq!(
         get_varargs::<4>(&a, args1, "test").unwrap(),
-        ([a3, 0, 0, 0], 1)
+        ([a3, NodePtr(0), NodePtr(0), NodePtr(0)], 1)
     );
     assert_eq!(
         get_varargs::<4>(&a, args0, "test").unwrap(),
-        ([0, 0, 0, 0], 0)
+        ([NodePtr(0), NodePtr(0), NodePtr(0), NodePtr(0)], 0)
     );
 
     let r = get_varargs::<3>(&a, args4, "test").unwrap_err();

--- a/src/serde/object_cache.rs
+++ b/src/serde/object_cache.rs
@@ -30,11 +30,11 @@ pub struct ObjectCache<'a, T> {
 /// and negative values become odd indices.
 
 fn node_to_index(node: &NodePtr) -> usize {
-    let node = *node;
-    if node < 0 {
-        (-node - node - 1) as usize
+    let value = node.0;
+    if value < 0 {
+        (-value - value - 1) as usize
     } else {
-        (node + node) as usize
+        (value + value) as usize
     }
 }
 
@@ -264,11 +264,11 @@ fn test_serialized_length() {
 
 #[test]
 fn test_node_to_index() {
-    assert_eq!(node_to_index(&0), 0);
-    assert_eq!(node_to_index(&1), 2);
-    assert_eq!(node_to_index(&2), 4);
-    assert_eq!(node_to_index(&-1), 1);
-    assert_eq!(node_to_index(&-2), 3);
+    assert_eq!(node_to_index(&NodePtr(0)), 0);
+    assert_eq!(node_to_index(&NodePtr(1)), 2);
+    assert_eq!(node_to_index(&NodePtr(2)), 4);
+    assert_eq!(node_to_index(&NodePtr(-1)), 1);
+    assert_eq!(node_to_index(&NodePtr(-2)), 3);
 }
 
 // this test takes a very long time (>60s) in debug mode, so it only runs in release mode

--- a/tools/src/bin/benchmark-clvm-cost.rs
+++ b/tools/src/bin/benchmark-clvm-cost.rs
@@ -16,7 +16,7 @@ enum OpArgs {
 
 // special argument to indicate it should be substituted for varied in the FreeBytes test to
 // measure cost per byte
-const VARIABLE: NodePtr = 999;
+const VARIABLE: NodePtr = NodePtr(999);
 
 // builds calls in the form:
 // (<op> arg arg ...)


### PR DESCRIPTION
This encapsulates `NodePtr` as a separate type (with all necessary traits derived) rather than a type alias to `i32`. This prevents typos or mistakes where you would use `NodePtr` somewhere that expects a normal `i32` or vice versa. It also allows separate implementations of traits, for example encoding and decoding a `NodePtr` with a CLVM allocator would be a no-op, whereas `i32` is encoded as an atom.