### PR TITLE
Switch to trusted publishing for pypi

### DIFF
--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build_wheels:
     name: ARM64 Python Wheels on ARM64 Ubuntu
@@ -67,25 +71,12 @@ jobs:
         pip install setuptools_rust
         pip install twine
 
-    - name: Test for secrets access
-      id: check_secrets
-      shell: bash
-      run: |
-        unset HAS_SECRET
-        if [ -n "$SECRET" ]; then HAS_SECRET='true' ; fi
-        echo "HAS_SECRET=${HAS_SECRET}" >>$GITHUB_OUTPUT
-      env:
-        SECRET: "${{ secrets.test_pypi_password }}"
-
     - name: publish (PyPi)
-      if: startsWith(github.event.ref, 'refs/tags') && steps.check_secrets.outputs.HAS_SECRET
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_NON_INTERACTIVE: 1
-        TWINE_PASSWORD: ${{ secrets.pypi_password }}
-      run: |
-        . ./activate
-        twine upload --non-interactive --skip-existing --verbose 'target/wheels/*'
+      if: startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: target/wheels/
+        skip-existing: true
 
     - name: Clean up AMR64
       if: startsWith(matrix.os, 'ARM64')

--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -69,7 +69,6 @@ jobs:
         if [ ! -f "activate" ]; then ln -s venv/bin/activate; fi
         . ./activate
         pip install setuptools_rust
-        pip install twine
 
     - name: publish (PyPi)
       if: startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -103,11 +103,6 @@ jobs:
         name: wheels
         path: ./target/wheels
 
-    - name: Install twine
-      run: |
-        . ./venv/bin/activate
-        pip install twine
-
     - name: Publish distribution to PyPI
       if: startsWith(github.event.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build_wheels:
     name: Build wheel on Mac M1
-    runs-on: [m1]
+    runs-on: [MacOS, ARM64]
     strategy:
       fail-fast: false
 

--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -15,6 +15,10 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}-${{ github.event_name }}--${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/heads/long_lived/')) && github.sha || '' }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build_wheels:
     name: Build wheel on Mac M1
@@ -99,27 +103,14 @@ jobs:
         name: wheels
         path: ./target/wheels
 
-    - name: Test for secrets access
-      id: check_secrets
-      shell: bash
-      run: |
-        unset HAS_SECRET
-        if [ -n "$SECRET" ]; then HAS_SECRET='true' ; fi
-        echo "HAS_SECRET=${HAS_SECRET}" >>$GITHUB_OUTPUT
-      env:
-        SECRET: "${{ secrets.test_pypi_password }}"
-
     - name: Install twine
       run: |
         . ./venv/bin/activate
         arch -arm64 pip install twine
 
     - name: Publish distribution to PyPI
-      if: startsWith(github.event.ref, 'refs/tags') && steps.check_secrets.outputs.HAS_SECRET
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_NON_INTERACTIVE: 1
-        TWINE_PASSWORD: ${{ secrets.pypi_password }}
-      run: |
-        . ./venv/bin/activate
-        arch -arm64 twine upload --non-interactive --skip-existing --verbose 'target/wheels/*'
+      if: startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: target/wheels/
+        skip-existing: true

--- a/.github/workflows/build-m1-wheel.yml
+++ b/.github/workflows/build-m1-wheel.yml
@@ -37,56 +37,56 @@ jobs:
     - name: Set up rust
       run: |
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > rust.sh
-        arch -arm64 sh rust.sh -y
+        sh rust.sh -y
 
     - name: Build m1 wheels
       run: |
-        arch -arm64 python3 -m venv venv
+        python3 -m venv venv
         . ./venv/bin/activate
         export PATH=~/.cargo/bin:$PATH
-        arch -arm64 pip install maturin
-        arch -arm64 maturin build -m wheel/Cargo.toml -i python --release --strip --features=openssl
+        pip install maturin
+        maturin build -m wheel/Cargo.toml -i python --release --strip --features=openssl
 
     - name: Install clvm_rs wheel
       run: |
         . ./venv/bin/activate
         ls ./target/wheels/
-        arch -arm64 pip install ./target/wheels/clvm_rs*.whl
+        pip install ./target/wheels/clvm_rs*.whl
 
     - name: Install other wheels
       run: |
         . ./venv/bin/activate
-        arch -arm64 python -m pip install pytest
-        arch -arm64 python -m pip install blspy
+        python -m pip install pytest
+        python -m pip install blspy
 
     - name: install clvm & clvm_tools
       run: |
         . ./venv/bin/activate
-        arch -arm64 git clone https://github.com/Chia-Network/clvm.git --branch=main --single-branch
-        arch -arm64 python -m pip install ./clvm
+        git clone https://github.com/Chia-Network/clvm.git --branch=main --single-branch
+        python -m pip install ./clvm
 
-        arch -arm64 git clone https://github.com/Chia-Network/clvm_tools.git --branch=main --single-branch
-        arch -arm64 python -m pip install ./clvm_tools
+        git clone https://github.com/Chia-Network/clvm_tools.git --branch=main --single-branch
+        python -m pip install ./clvm_tools
 
     - name: Ensure clvm, clvm_rs, clvm_tools are installed
       run: |
         . ./venv/bin/activate
-        arch -arm64 python -c 'import clvm'
-        arch -arm64 python -c 'import clvm; print(clvm.__file__)'
-        arch -arm64 python -c 'import clvm_rs; print(clvm_rs.__file__)'
-        arch -arm64 python -c 'import clvm_tools; print(clvm_tools.__file__)'
+        python -c 'import clvm'
+        python -c 'import clvm; print(clvm.__file__)'
+        python -c 'import clvm_rs; print(clvm_rs.__file__)'
+        python -c 'import clvm_tools; print(clvm_tools.__file__)'
 
     - name: Run tests from clvm
       run: |
         . ./venv/bin/activate
         cd clvm
-        arch -arm64 pytest tests
+        pytest tests
 
     - name: Run tests from clvm_tools
       run: |
         . ./venv/bin/activate
         cd clvm_tools
-        arch -arm64 pytest tests
+        pytest tests
 
     - name: Run tests from wheel
       run: |
@@ -106,7 +106,7 @@ jobs:
     - name: Install twine
       run: |
         . ./venv/bin/activate
-        arch -arm64 pip install twine
+        pip install twine
 
     - name: Publish distribution to PyPI
       if: startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -133,9 +133,6 @@ jobs:
         name: wheels
         path: ./target/wheels/
 
-    - name: Install Twine
-      run: pip install twine
-
     - name: publish (PyPi)
       if: startsWith(github.event.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build_wheels:
     name: Wheel on ${{ matrix.os }} py-${{ matrix.python }}
@@ -132,23 +136,12 @@ jobs:
     - name: Install Twine
       run: pip install twine
 
-    - name: Test for secrets access
-      id: check_secrets
-      shell: bash
-      run: |
-        unset HAS_SECRET
-        if [ -n "$SECRET" ]; then HAS_SECRET='true' ; fi
-        echo "HAS_SECRET=${HAS_SECRET}" >>$GITHUB_OUTPUT
-      env:
-        SECRET: "${{ secrets.test_pypi_password }}"
-
     - name: publish (PyPi)
-      if: startsWith(github.event.ref, 'refs/tags') && steps.check_secrets.outputs.HAS_SECRET
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_NON_INTERACTIVE: 1
-        TWINE_PASSWORD: ${{ secrets.pypi_password }}
-      run: twine upload --non-interactive --skip-existing --verbose 'target/wheels/*'
+      if: startsWith(github.event.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: target/wheels/
+        skip-existing: true
 
   checks:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
With some additional housekeeping coming from review comments:
- `arch -arm64` in m1 wheel job commands no longer required, this job originally ran on intel procs which did require this command prefix.
- Use more generic macos/arm64 runner tags in preparation for future M2 runners