### PR TITLE
simplify raw-loops into while-loops

### DIFF
--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -19,12 +19,8 @@ pub fn node_from_stream(allocator: &mut Allocator, f: &mut Cursor<&[u8]>) -> io:
     let mut ops = vec![ParseOp::SExp];
 
     let mut b = [0; 1];
-    loop {
-        let op = ops.pop();
-        if op.is_none() {
-            break;
-        }
-        match op.unwrap() {
+    while let Some(op) = ops.pop() {
+        match op {
             ParseOp::SExp => {
                 f.read_exact(&mut b)?;
                 if b[0] == CONS_BOX_MARKER {

--- a/src/serde/de_br.rs
+++ b/src/serde/de_br.rs
@@ -24,12 +24,8 @@ pub fn node_from_stream_backrefs(
     let mut ops = vec![ParseOp::SExp];
 
     let mut b = [0; 1];
-    loop {
-        let op = ops.pop();
-        if op.is_none() {
-            break;
-        }
-        match op.unwrap() {
+    while let Some(op) = ops.pop() {
+        match op {
             ParseOp::SExp => {
                 f.read_exact(&mut b)?;
                 if b[0] == CONS_BOX_MARKER {

--- a/src/serde/object_cache.rs
+++ b/src/serde/object_cache.rs
@@ -78,30 +78,23 @@ impl<'a, T: Clone> ObjectCache<'a, T> {
     /// as necessary
     fn calculate(&mut self, root_node: &NodePtr) {
         let mut obj_list = vec![*root_node];
-        loop {
-            match obj_list.pop() {
-                None => {
-                    return;
-                }
-                Some(node) => {
-                    let v = self.get_from_cache(&node);
-                    match v {
-                        Some(_) => {}
-                        None => match (self.f)(self, self.allocator, node) {
-                            None => match self.allocator.sexp(node) {
-                                SExp::Pair(left, right) => {
-                                    obj_list.push(node);
-                                    obj_list.push(left);
-                                    obj_list.push(right);
-                                }
-                                _ => panic!("f returned `None` for atom"),
-                            },
-                            Some(v) => {
-                                self.set(&node, v);
-                            }
-                        },
+        while let Some(node) = obj_list.pop() {
+            let v = self.get_from_cache(&node);
+            match v {
+                Some(_) => {}
+                None => match (self.f)(self, self.allocator, node) {
+                    None => match self.allocator.sexp(node) {
+                        SExp::Pair(left, right) => {
+                            obj_list.push(node);
+                            obj_list.push(left);
+                            obj_list.push(right);
+                        }
+                        _ => panic!("f returned `None` for atom"),
+                    },
+                    Some(v) => {
+                        self.set(&node, v);
                     }
-                }
+                },
             }
         }
     }

--- a/src/serde/read_cache_lookup.rs
+++ b/src/serde/read_cache_lookup.rs
@@ -135,10 +135,7 @@ impl ReadCacheLookup {
         seen_ids.insert(id);
         let mut partial_paths = vec![(*id, vec![])];
 
-        loop {
-            if partial_paths.is_empty() {
-                break;
-            }
+        while !partial_paths.is_empty() {
             let mut new_partial_paths = vec![];
             for (node, path) in partial_paths.iter_mut() {
                 if *node == self.root_hash {

--- a/src/serde/tools.rs
+++ b/src/serde/tools.rs
@@ -74,12 +74,8 @@ pub fn tree_hash_from_stream(f: &mut Cursor<&[u8]>) -> io::Result<[u8; 32]> {
     let mut ops = vec![ParseOp::SExp];
 
     let mut b = [0; 1];
-    loop {
-        let op = ops.pop();
-        if op.is_none() {
-            break;
-        }
-        match op.unwrap() {
+    while let Some(op) = ops.pop() {
+        match op {
             ParseOp::SExp => {
                 f.read_exact(&mut b)?;
                 if b[0] == CONS_BOX_MARKER {


### PR DESCRIPTION
in some cases this saves one or two levels of indentation of the loop body.
It always saves a few lines of code. It makes it more idiomatic rust I believe.