### PR TITLE
Revert "bump openssl"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ bls12_381 = { version = "=0.8.0", features = ["experimental"] }
 # the newer sha2 crate doesn't implement the digest traits required by HKDF
 group = "=0.13.0"
 sha2 = "=0.9.9"
-openssl = { version = ">=0.10.55", features = ["vendored"], optional = true }
+openssl = { version = "=0.10.55", features = ["vendored"], optional = true }
 getrandom = { version = "=0.2.9", features = ["js" ]}
 # for secp sigs
 k256 = { version = "0.13.1", features = ["ecdsa"] }


### PR DESCRIPTION
This reverts commit 28fe77c3ce2d21d7707af8941343a48433e18dd4.

Except not quite. There was a security alert if I would go all the way back to that version of OpenSSL.

The purpose of this is to fix CI