### PR TITLE
Bump chia-bls and clvm-traits, as well as clvmr version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,47 +60,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "bls12_381"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc6d6292be3a19e6379786dac800f551e5865a5bb51ebbe3064ab80433f403"
-dependencies = [
- "digest 0.9.0",
- "ff",
- "group",
- "pairing",
- "rand_core",
- "subtle",
 ]
 
 [[package]]
@@ -145,18 +110,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chia-bls"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f02b3316f347607f79668627cf1f01b5a62257089c08e92c7df3ad93c6c1aa"
+checksum = "a72987625a992469b793a7aba42b29be55f9b9b35f8d55bb5b87a314274733c0"
 dependencies = [
  "anyhow",
  "arbitrary",
  "blst",
  "chia-traits",
- "clvm-traits 0.2.14",
  "hex",
  "hkdf",
- "sha2 0.10.8",
+ "sha2",
  "thiserror",
  "tiny-bip39",
 ]
@@ -169,7 +133,7 @@ checksum = "636e832ece4dc14e2e866d1737fbfdc32d6dd616aa4fc3869cfb273881def303"
 dependencies = [
  "chia_streamable_macro",
  "hex",
- "sha2 0.10.8",
+ "sha2",
  "thiserror",
 ]
 
@@ -250,23 +214,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "clvm-derive"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9110e638f8a4d34922e0436282c7fe1a8149020aef3aacf699377dcd3f1553da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.29",
-]
-
-[[package]]
 name = "clvm-rs-test-tools"
 version = "0.1.0"
 dependencies = [
  "chia-bls",
  "clap",
- "clvmr 0.3.1",
+ "clvmr",
  "hex",
  "hex-literal",
  "linreg",
@@ -279,21 +232,9 @@ dependencies = [
 
 [[package]]
 name = "clvm-traits"
-version = "0.2.14"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64ffd2241dead56ca31fb0261b4d0f802ba0b98a1c1e6f4514bc06c6095a9a9"
-dependencies = [
- "clvm-derive",
- "clvmr 0.3.0",
- "num-bigint",
- "thiserror",
-]
-
-[[package]]
-name = "clvm-traits"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa5c29efcbfc09a80251da9974959fc603f87197452e822b3b80f8622639b78"
+checksum = "02b527f38a1a9ef23aafd982a89be3881fa5f0a0ba0a642fa94244c72a74b8c8"
 dependencies = [
  "num-bigint",
  "thiserror",
@@ -303,7 +244,7 @@ dependencies = [
 name = "clvm_rs"
 version = "0.3.0"
 dependencies = [
- "clvmr 0.3.1",
+ "clvmr",
  "pyo3",
 ]
 
@@ -311,7 +252,7 @@ dependencies = [
 name = "clvm_rs-fuzz"
 version = "1.0.0"
 dependencies = [
- "clvmr 0.3.1",
+ "clvmr",
  "libfuzzer-sys",
 ]
 
@@ -319,7 +260,7 @@ dependencies = [
 name = "clvm_wasm"
 version = "0.3.0"
 dependencies = [
- "clvmr 0.3.1",
+ "clvmr",
  "js-sys",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -327,29 +268,10 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd344b6dc76235f446025fe9ebe54aa6131e2e59acb49e16be48a3bb3492491"
-dependencies = [
- "bls12_381",
- "getrandom",
- "group",
- "hex",
- "k256",
- "lazy_static",
- "num-bigint",
- "num-integer",
- "num-traits",
- "p256",
- "sha2 0.9.9",
-]
-
-[[package]]
-name = "clvmr"
 version = "0.3.1"
 dependencies = [
  "chia-bls",
- "clvm-traits 0.3.0",
+ "clvm-traits",
  "criterion",
  "hex",
  "k256",
@@ -360,7 +282,7 @@ dependencies = [
  "openssl",
  "p256",
  "rstest",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -502,20 +424,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
@@ -539,7 +452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -560,7 +473,7 @@ checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
@@ -605,7 +518,6 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "bitvec",
  "rand_core",
  "subtle",
 ]
@@ -624,12 +536,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -744,10 +650,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -818,7 +722,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -891,7 +795,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2 0.10.8",
+ "sha2",
  "signature",
 ]
 
@@ -1027,12 +931,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "openssl"
 version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,16 +993,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.8",
-]
-
-[[package]]
-name = "pairing"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
-dependencies = [
- "group",
+ "sha2",
 ]
 
 [[package]]
@@ -1136,7 +1025,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1330,12 +1219,6 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1577,20 +1460,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
@@ -1601,7 +1471,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1610,7 +1480,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core",
 ]
 
@@ -1674,12 +1544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "target-lexicon"
 version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,7 +1599,7 @@ dependencies = [
  "pbkdf2",
  "rand",
  "rustc-hash",
- "sha2 0.10.8",
+ "sha2",
  "thiserror",
  "unicode-normalization",
  "wasm-bindgen",
@@ -2043,15 +1907,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e87b8dfbe3baffbe687eef2e164e32286eff31a5ee16463ce03d991643ec94"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ name = "clvm_wasm"
 version = "0.3.2"
 dependencies = [
  "clvmr",
+ "getrandom",
  "js-sys",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -650,8 +651,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_rs"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "clvmr",
  "pyo3",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_wasm"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "clvmr",
  "js-sys",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chia-bls",
  "clvm-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["fuzz", "tools", "wasm", "wheel"]
 
 [package]
 name = "clvmr"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ lazy_static = "1.4.0"
 num-bigint = "0.4.3"
 num-traits = "0.2.15"
 num-integer = "0.1.45"
-clvm-traits = "0.3.0"
-chia-bls = "0.3.0"
+clvm-traits = "0.3.2"
+chia-bls = "0.3.1"
 sha2 = "0.10.8"
 openssl = { version = "=0.10.55", features = ["vendored"], optional = true }
 # for secp sigs

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_wasm"
-version = "0.3.0"
+version = "0.3.2"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2021"
 license = "Apache-2.0"

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -15,7 +15,8 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-clvmr = { path = "..", features = [] }
+clvmr = { path = ".." }
 wasm-bindgen = "=0.2.87"
 wasm-bindgen-test = "=0.3.34"
 js-sys = "0.3.61"
+getrandom = { version = "0.2.9", features = ["js"] }

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_rs"
-version = "0.3.0"
+version = "0.3.2"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
This is a (hopefully circular dependency free) bump of chia-bls and clvm-traits as the next step in migrating to blst and making clvm-traits implemented for Allocator here.

Also bumped the package version.