### PR TITLE
`NodePtr` internal representation

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -23,6 +23,11 @@ impl NodePtr {
         Self::new(ObjectType::Bytes, 0)
     }
 
+    // TODO: remove this
+    pub fn hack(val: usize) -> Self {
+        Self::new(ObjectType::Bytes, val)
+    }
+
     fn new(t: ObjectType, idx: usize) -> Self {
         assert!(idx <= NODE_PTR_IDX_MASK as usize);
         NodePtr(((t as u32) << NODE_PTR_IDX_BITS) | (idx as u32))

--- a/src/op_utils.rs
+++ b/src/op_utils.rs
@@ -18,7 +18,7 @@ pub fn get_args<const N: usize>(
 ) -> Result<[NodePtr; N], EvalErr> {
     let mut next = args;
     let mut counter = 0;
-    let mut ret: [NodePtr; N] = [NodePtr(0); N];
+    let mut ret: [NodePtr; N] = [NodePtr::null(); N];
 
     while let Some((first, rest)) = a.next(next) {
         next = rest;
@@ -91,7 +91,7 @@ pub fn get_varargs<const N: usize>(
 ) -> Result<([NodePtr; N], usize), EvalErr> {
     let mut next = args;
     let mut counter = 0;
-    let mut ret: [NodePtr; N] = [NodePtr(0); N];
+    let mut ret: [NodePtr; N] = [NodePtr::null(); N];
 
     while let Some((first, rest)) = a.next(next) {
         next = rest;
@@ -131,19 +131,27 @@ fn test_get_varargs() {
     );
     assert_eq!(
         get_varargs::<4>(&a, args3, "test").unwrap(),
-        ([a1, a2, a3, NodePtr(0)], 3)
+        ([a1, a2, a3, NodePtr::null()], 3)
     );
     assert_eq!(
         get_varargs::<4>(&a, args2, "test").unwrap(),
-        ([a2, a3, NodePtr(0), NodePtr(0)], 2)
+        ([a2, a3, NodePtr::null(), NodePtr::null()], 2)
     );
     assert_eq!(
         get_varargs::<4>(&a, args1, "test").unwrap(),
-        ([a3, NodePtr(0), NodePtr(0), NodePtr(0)], 1)
+        ([a3, NodePtr::null(), NodePtr::null(), NodePtr::null()], 1)
     );
     assert_eq!(
         get_varargs::<4>(&a, args0, "test").unwrap(),
-        ([NodePtr(0), NodePtr(0), NodePtr(0), NodePtr(0)], 0)
+        (
+            [
+                NodePtr::null(),
+                NodePtr::null(),
+                NodePtr::null(),
+                NodePtr::null()
+            ],
+            0
+        )
     );
 
     let r = get_varargs::<3>(&a, args4, "test").unwrap_err();

--- a/tools/src/bin/benchmark-clvm-cost.rs
+++ b/tools/src/bin/benchmark-clvm-cost.rs
@@ -16,7 +16,7 @@ enum OpArgs {
 
 // special argument to indicate it should be substituted for varied in the FreeBytes test to
 // measure cost per byte
-const VARIABLE: NodePtr = NodePtr(999);
+const VARIABLE_VAL: usize = 999;
 
 // builds calls in the form:
 // (<op> arg arg ...)
@@ -99,9 +99,10 @@ fn quote(a: &mut Allocator, v: NodePtr) -> NodePtr {
 }
 
 fn subst_node(arg: NodePtr, substitution: NodePtr) -> NodePtr {
-    match arg {
-        VARIABLE => substitution,
-        _ => arg,
+    if arg == NodePtr::hack(VARIABLE_VAL) {
+        substitution
+    } else {
+        arg
     }
 }
 
@@ -337,6 +338,8 @@ pub fn main() {
 
     let mut a = Allocator::new();
 
+    let variable = NodePtr::hack(VARIABLE_VAL);
+
     let g1 = a.new_atom(&hex::decode("97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb").unwrap()).unwrap();
     let g2 = a.new_atom(&hex::decode("93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8").unwrap()).unwrap();
 
@@ -386,21 +389,21 @@ pub fn main() {
         Operator {
             opcode: 60,
             name: "modpow (modulus cost)",
-            arg: OpArgs::ThreeArgs(number, number, VARIABLE),
+            arg: OpArgs::ThreeArgs(number, number, variable),
             extra: None,
             flags: PER_BYTE_COST | EXPONENTIAL_COST,
         },
         Operator {
             opcode: 60,
             name: "modpow (exponent cost)",
-            arg: OpArgs::ThreeArgs(number, VARIABLE, number),
+            arg: OpArgs::ThreeArgs(number, variable, number),
             extra: None,
             flags: PER_BYTE_COST | EXPONENTIAL_COST,
         },
         Operator {
             opcode: 60,
             name: "modpow (value cost)",
-            arg: OpArgs::ThreeArgs(VARIABLE, number, number),
+            arg: OpArgs::ThreeArgs(variable, number, number),
             extra: None,
             flags: PER_BYTE_COST,
         },
@@ -421,7 +424,7 @@ pub fn main() {
         Operator {
             opcode: 50,
             name: "g1_multiply",
-            arg: OpArgs::TwoArgs(g1, VARIABLE),
+            arg: OpArgs::TwoArgs(g1, variable),
             extra: Some(g1),
             flags: PER_BYTE_COST,
         },
@@ -449,7 +452,7 @@ pub fn main() {
         Operator {
             opcode: 54,
             name: "g2_multiply",
-            arg: OpArgs::TwoArgs(g2, VARIABLE),
+            arg: OpArgs::TwoArgs(g2, variable),
             extra: Some(g2),
             flags: PER_BYTE_COST,
         },
@@ -463,14 +466,14 @@ pub fn main() {
         Operator {
             opcode: 56,
             name: "g1_map",
-            arg: OpArgs::SingleArg(VARIABLE),
+            arg: OpArgs::SingleArg(variable),
             extra: None,
             flags: PER_BYTE_COST | LARGE_BUFFERS,
         },
         Operator {
             opcode: 57,
             name: "g2_map",
-            arg: OpArgs::SingleArg(VARIABLE),
+            arg: OpArgs::SingleArg(variable),
             extra: None,
             flags: PER_BYTE_COST | LARGE_BUFFERS,
         },


### PR DESCRIPTION
This patch changes the internal representation of `NodePtr` to use the top 6 bits as "type" and the bottom 26 bits for "index". Currently we use positive numbers for atoms and negative numbers for pairs. The new representation supports more types.

For example, we may want to have atoms in `BigInt`, `G1` or `G2` formats internally. These could be new types.

But perhaps the most important optimization this opens up is to have atoms point to external buffers. e.g. when running a program stored in a buffer, we could have atoms point directly into that buffer rather than copying everything into the `Allocator` object first.