### PR TITLE
rename null() to nil() for better alignment with LISP

### DIFF
--- a/benches/run-program.rs
+++ b/benches/run-program.rs
@@ -6,7 +6,7 @@ use std::fs::read_to_string;
 use std::time::Instant;
 
 fn long_strings(a: &mut Allocator) -> NodePtr {
-    let mut list = a.null();
+    let mut list = a.nil();
     for _i in 0..1000 {
         let item = a
             .new_atom(b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
@@ -14,7 +14,7 @@ fn long_strings(a: &mut Allocator) -> NodePtr {
         list = a.new_pair(item, list).expect("new_pair");
     }
 
-    a.new_pair(list, a.null()).expect("new_pair")
+    a.new_pair(list, a.nil()).expect("new_pair")
 }
 
 fn large_tree_impl(a: &mut Allocator, depth: i32) -> NodePtr {
@@ -37,11 +37,11 @@ fn long_string(a: &mut Allocator) -> NodePtr {
         atom.extend(b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
     }
     let item = a.new_atom(&atom[..]).expect("new_atom");
-    a.new_pair(item, a.null()).expect("new_pair")
+    a.new_pair(item, a.nil()).expect("new_pair")
 }
 
 fn tuple3<const N: i32, const K: i32>(a: &mut Allocator) -> NodePtr {
-    let list = a.null();
+    let list = a.nil();
     let item = a.new_number(K.into()).expect("new_atom");
     let list = a.new_pair(item, list).expect("new_pair");
     let item = a.new_number(N.into()).expect("new_atom");
@@ -51,7 +51,7 @@ fn tuple3<const N: i32, const K: i32>(a: &mut Allocator) -> NodePtr {
 }
 
 fn pair<const N: i32>(a: &mut Allocator) -> NodePtr {
-    let list = a.null();
+    let list = a.nil();
     let item = a.new_number(N.into()).expect("new_atom");
     let list = a.new_pair(item, list).expect("new_pair");
     let item = a
@@ -61,18 +61,18 @@ fn pair<const N: i32>(a: &mut Allocator) -> NodePtr {
 }
 
 fn single_value<const N: i32>(a: &mut Allocator) -> NodePtr {
-    let list = a.null();
+    let list = a.nil();
     let item = a.new_number(N.into()).expect("new_atom");
     a.new_pair(item, list).expect("new_pair")
 }
 
 fn generate_list<const N: i32>(a: &mut Allocator) -> NodePtr {
-    let mut list = a.null();
+    let mut list = a.nil();
     for _i in 0..N {
         let item = a.new_number(42.into()).expect("new_atom");
         list = a.new_pair(item, list).expect("new_pair");
     }
-    a.new_pair(list, a.null()).expect("new_pair")
+    a.new_pair(list, a.nil()).expect("new_pair")
 }
 
 fn large_block(a: &mut Allocator) -> NodePtr {
@@ -81,7 +81,7 @@ fn large_block(a: &mut Allocator) -> NodePtr {
         buffer.push((i & 0xff) as u8);
     }
 
-    let mut list = a.null();
+    let mut list = a.nil();
     for i in 0..1000 {
         let hex_key1 = hex::encode(&buffer[i..i + 32]);
         let hex_key2 = hex::encode(&buffer[i / 2..i / 2 + 32]);
@@ -118,13 +118,13 @@ ff83\
 }
 
 fn matrix<const W: i32, const H: i32>(a: &mut Allocator) -> NodePtr {
-    let mut args = a.null();
+    let mut args = a.nil();
 
     for _l in 0..2 {
-        let mut col = a.null();
+        let mut col = a.nil();
 
         for _k in 0..H {
-            let mut row = a.null();
+            let mut row = a.nil();
             for _i in 0..W {
                 let val = a.new_atom(b"ccba9401").expect("new_atom");
                 row = a.new_pair(val, row).expect("new_pair");
@@ -177,11 +177,11 @@ ffff01ffff33ffa06b7a83babea1eec790c947db4464ab657dbe9b887fe9acc2\
 }
 
 fn none(a: &mut Allocator) -> NodePtr {
-    a.null()
+    a.nil()
 }
 
 fn point_pow(a: &mut Allocator) -> NodePtr {
-    let list = a.null();
+    let list = a.nil();
     let item = a.new_number(1337.into()).expect("new_atom");
     let list = a.new_pair(item, list).expect("new_pair");
     let item = a.new_atom(&hex::decode("b3b8ac537f4fd6bde9b26221d49b54b17a506be147347dae5d081c0a6572b611d8484e338f3432971a9823976c6a232b").expect("invalid point hex")).expect("new_atom");

--- a/fuzz/fuzz_targets/fuzzing_utils.rs
+++ b/fuzz/fuzz_targets/fuzzing_utils.rs
@@ -56,7 +56,7 @@ const BUFFER: [u8; 63] = [
 
 pub fn make_tree(a: &mut Allocator, cursor: &mut BitCursor, short_atoms: bool) -> NodePtr {
     match cursor.read_bits(1) {
-        None => a.null(),
+        None => a.nil(),
         Some(0) => {
             let first = make_tree(a, cursor, short_atoms);
             let second = make_tree(a, cursor, short_atoms);
@@ -65,12 +65,12 @@ pub fn make_tree(a: &mut Allocator, cursor: &mut BitCursor, short_atoms: bool) -
         Some(_) => {
             if short_atoms {
                 match cursor.read_bits(8) {
-                    None => a.null(),
+                    None => a.nil(),
                     Some(val) => a.new_atom(&[val]).unwrap(),
                 }
             } else {
                 match cursor.read_bits(6) {
-                    None => a.null(),
+                    None => a.nil(),
                     Some(len) => a.new_atom(&BUFFER[..len as usize]).unwrap(),
                 }
             }

--- a/fuzz/fuzz_targets/run_program.rs
+++ b/fuzz/fuzz_targets/run_program.rs
@@ -18,7 +18,7 @@ fuzz_target!(|data: &[u8]| {
         }
         Ok(r) => r,
     };
-    let args = allocator.null();
+    let args = allocator.nil();
 
     let allocator_checkpoint = allocator.checkpoint();
 

--- a/src/bls_ops.rs
+++ b/src/bls_ops.rs
@@ -2,7 +2,7 @@ use crate::allocator::{Allocator, NodePtr};
 use crate::cost::{check_cost, Cost};
 use crate::err_utils::err;
 use crate::op_utils::{
-    atom, first, get_args, get_varargs, int_atom, mod_group_order, new_atom_and_cost, nullp, rest,
+    atom, first, get_args, get_varargs, int_atom, mod_group_order, new_atom_and_cost, nilp, rest,
     MALLOC_COST_PER_BYTE,
 };
 use crate::reduction::{EvalErr, Reduction, Response};
@@ -272,7 +272,7 @@ pub fn op_bls_pairing_identity(a: &mut Allocator, input: NodePtr, max_cost: Cost
     let mut items = Vec::<(G1Element, G2Element)>::new();
 
     let mut args = input;
-    while !nullp(a, args) {
+    while !nilp(a, args) {
         cost += BLS_PAIRING_COST_PER_ARG;
         check_cost(a, cost, max_cost)?;
         let g1 = a.g1(first(a, args)?)?;
@@ -285,7 +285,7 @@ pub fn op_bls_pairing_identity(a: &mut Allocator, input: NodePtr, max_cost: Cost
     if !aggregate_pairing(items) {
         err(input, "bls_pairing_identity failed")
     } else {
-        Ok(Reduction(cost, a.null()))
+        Ok(Reduction(cost, a.nil()))
     }
 }
 
@@ -306,7 +306,7 @@ pub fn op_bls_verify(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Respo
     args = rest(a, args)?;
 
     let mut items = Vec::<(PublicKey, &[u8])>::new();
-    while !nullp(a, args) {
+    while !nilp(a, args) {
         let pk = a.g1(first(a, args)?)?;
         args = rest(a, args)?;
         let msg = atom(a, first(a, args)?, "bls_verify message")?;
@@ -323,6 +323,6 @@ pub fn op_bls_verify(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Respo
     if !aggregate_verify(&signature, items) {
         err(input, "bls_verify failed")
     } else {
-        Ok(Reduction(cost, a.null()))
+        Ok(Reduction(cost, a.nil()))
     }
 }

--- a/src/core_ops.rs
+++ b/src/core_ops.rs
@@ -1,7 +1,7 @@
 use crate::allocator::{Allocator, NodePtr, SExp};
 use crate::cost::Cost;
 use crate::err_utils::err;
-use crate::op_utils::{first, get_args, nullp, rest};
+use crate::op_utils::{first, get_args, nilp, rest};
 use crate::reduction::{EvalErr, Reduction, Response};
 
 const FIRST_COST: Cost = 30;
@@ -17,11 +17,7 @@ const EQ_COST_PER_BYTE: Cost = 1;
 
 pub fn op_if(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     let [cond, affirmative, negative] = get_args::<3>(a, input, "i")?;
-    let chosen_node = if nullp(a, cond) {
-        negative
-    } else {
-        affirmative
-    };
+    let chosen_node = if nilp(a, cond) { negative } else { affirmative };
     Ok(Reduction(IF_COST, chosen_node))
 }
 
@@ -45,7 +41,7 @@ pub fn op_listp(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response 
     let [n] = get_args::<1>(a, input, "l")?;
     match a.sexp(n) {
         SExp::Pair(_, _) => Ok(Reduction(LISTP_COST, a.one())),
-        _ => Ok(Reduction(LISTP_COST, a.null())),
+        _ => Ok(Reduction(LISTP_COST, a.nil())),
     }
 }
 
@@ -80,5 +76,5 @@ pub fn op_eq(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     ensure_atom(a, s1, "=")?;
     let eq = a.atom_eq(s0, s1);
     let cost = EQ_BASE_COST + (a.atom_len(s0) as Cost + a.atom_len(s1) as Cost) * EQ_COST_PER_BYTE;
-    Ok(Reduction(cost, if eq { a.one() } else { a.null() }))
+    Ok(Reduction(cost, if eq { a.one() } else { a.nil() }))
 }

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -5,7 +5,7 @@ pub type Cost = u64;
 
 pub fn check_cost(a: &Allocator, cost: Cost, max_cost: Cost) -> Result<(), EvalErr> {
     if cost > max_cost {
-        Err(EvalErr(a.null(), "cost exceeded".into()))
+        Err(EvalErr(a.nil(), "cost exceeded".into()))
     } else {
         Ok(())
     }

--- a/src/op_utils.rs
+++ b/src/op_utils.rs
@@ -18,7 +18,7 @@ pub fn get_args<const N: usize>(
 ) -> Result<[NodePtr; N], EvalErr> {
     let mut next = args;
     let mut counter = 0;
-    let mut ret: [NodePtr; N] = [NodePtr::null(); N];
+    let mut ret: [NodePtr; N] = [NodePtr::nil(); N];
 
     while let Some((first, rest)) = a.next(next) {
         next = rest;
@@ -55,7 +55,7 @@ fn test_get_args() {
     let a1 = a.new_number(1337.into()).unwrap();
     let a2 = a.new_number(0.into()).unwrap();
     let a3 = a.new_atom(&[]).unwrap();
-    let args0 = a.null();
+    let args0 = a.nil();
     let args1 = a.new_pair(a3, args0).unwrap();
     let args2 = a.new_pair(a2, args1).unwrap();
     let args3 = a.new_pair(a1, args2).unwrap();
@@ -91,7 +91,7 @@ pub fn get_varargs<const N: usize>(
 ) -> Result<([NodePtr; N], usize), EvalErr> {
     let mut next = args;
     let mut counter = 0;
-    let mut ret: [NodePtr; N] = [NodePtr::null(); N];
+    let mut ret: [NodePtr; N] = [NodePtr::nil(); N];
 
     while let Some((first, rest)) = a.next(next) {
         next = rest;
@@ -118,7 +118,7 @@ fn test_get_varargs() {
     let a1 = a.new_number(1337.into()).unwrap();
     let a2 = a.new_number(0.into()).unwrap();
     let a3 = a.new_atom(&[]).unwrap();
-    let args0 = a.null();
+    let args0 = a.nil();
     let args1 = a.new_pair(a3, args0).unwrap();
     let args2 = a.new_pair(a2, args1).unwrap();
     let args3 = a.new_pair(a1, args2).unwrap();
@@ -131,24 +131,24 @@ fn test_get_varargs() {
     );
     assert_eq!(
         get_varargs::<4>(&a, args3, "test").unwrap(),
-        ([a1, a2, a3, NodePtr::null()], 3)
+        ([a1, a2, a3, NodePtr::nil()], 3)
     );
     assert_eq!(
         get_varargs::<4>(&a, args2, "test").unwrap(),
-        ([a2, a3, NodePtr::null(), NodePtr::null()], 2)
+        ([a2, a3, NodePtr::nil(), NodePtr::nil()], 2)
     );
     assert_eq!(
         get_varargs::<4>(&a, args1, "test").unwrap(),
-        ([a3, NodePtr::null(), NodePtr::null(), NodePtr::null()], 1)
+        ([a3, NodePtr::nil(), NodePtr::nil(), NodePtr::nil()], 1)
     );
     assert_eq!(
         get_varargs::<4>(&a, args0, "test").unwrap(),
         (
             [
-                NodePtr::null(),
-                NodePtr::null(),
-                NodePtr::null(),
-                NodePtr::null()
+                NodePtr::nil(),
+                NodePtr::nil(),
+                NodePtr::nil(),
+                NodePtr::nil()
             ],
             0
         )
@@ -163,7 +163,7 @@ fn test_get_varargs() {
     assert_eq!(r.1, "test takes no more than 1 argument");
 }
 
-pub fn nullp(a: &Allocator, n: NodePtr) -> bool {
+pub fn nilp(a: &Allocator, n: NodePtr) -> bool {
     match a.sexp(n) {
         SExp::Atom => a.atom_len(n) == 0,
         _ => false,
@@ -171,20 +171,20 @@ pub fn nullp(a: &Allocator, n: NodePtr) -> bool {
 }
 
 #[test]
-fn test_nullp() {
+fn test_nilp() {
     let mut a = Allocator::new();
     let a0 = a.new_number(42.into()).unwrap();
     let a1 = a.new_number(1337.into()).unwrap();
     let a3 = a.new_number(0.into()).unwrap();
     let a4 = a.new_atom(&[]).unwrap();
-    let a5 = a.null();
+    let a5 = a.nil();
     let pair = a.new_pair(a0, a1).unwrap();
-    assert!(!nullp(&a, pair));
-    assert!(!nullp(&a, a0));
-    assert!(!nullp(&a, a1));
-    assert!(nullp(&a, a3));
-    assert!(nullp(&a, a4));
-    assert!(nullp(&a, a5));
+    assert!(!nilp(&a, pair));
+    assert!(!nilp(&a, a0));
+    assert!(!nilp(&a, a1));
+    assert!(nilp(&a, a3));
+    assert!(nilp(&a, a4));
+    assert!(nilp(&a, a5));
 }
 
 pub fn first(a: &Allocator, n: NodePtr) -> Result<NodePtr, EvalErr> {

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -152,7 +152,7 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
         let v: Option<NodePtr> = self.val_stack.pop();
         match v {
             None => {
-                let node: NodePtr = self.allocator.null();
+                let node: NodePtr = self.allocator.nil();
                 err(node, "runtime error: value stack empty")
             }
             Some(k) => Ok(k),
@@ -256,11 +256,11 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
                 self.push(first)?;
                 operands = rest;
             }
-            // ensure a correct null terminator
+            // ensure a correct nil terminator
             if !self.allocator.atom(operands).is_empty() {
                 err(operand_list, "bad operand list")
             } else {
-                self.push(self.allocator.null())?;
+                self.push(self.allocator.nil())?;
                 Ok(OP_COST)
             }
         }
@@ -374,7 +374,7 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
                         // that doesn't pass the correct arguments.
                         // if we're in consensus mode, we have to accept this as
                         // something we don't understand
-                        self.push(self.allocator.null())?;
+                        self.push(self.allocator.nil())?;
                         return Ok(expected_cost);
                     }
                     return Err(err);
@@ -428,22 +428,22 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
                 current_cost - guard.start_cost,
                 guard.expected_cost - guard.start_cost
             );
-            return err(self.allocator.null(), "softfork specified cost mismatch");
+            return err(self.allocator.nil(), "softfork specified cost mismatch");
         }
 
         // restore the allocator to the state when we entered the softfork guard
         // This is an optimization to reclaim all heap space allocated by the
-        // softfork program. Since the softfork always return null, no value can
+        // softfork program. Since the softfork always return nil, no value can
         // escape the softfork program, and it's therefore safe to restore the
         // heap
         self.allocator.restore_checkpoint(&guard.allocator_state);
 
-        // the softfork always returns null, pop the value pushed by the
-        // evaluation of the program and push null instead
+        // the softfork always returns nil, pop the value pushed by the
+        // evaluation of the program and push nil instead
         self.pop()
             .expect("internal error, softfork program did not push value onto stack");
 
-        self.push(self.allocator.null())?;
+        self.push(self.allocator.nil())?;
 
         Ok(0)
     }

--- a/src/secp_ops.rs
+++ b/src/secp_ops.rs
@@ -39,7 +39,7 @@ pub fn op_secp256r1_verify(a: &mut Allocator, input: NodePtr, max_cost: Cost) ->
     if result.is_err() {
         err(input, "secp256r1_verify failed")
     } else {
-        Ok(Reduction(cost, a.null()))
+        Ok(Reduction(cost, a.nil()))
     }
 }
 
@@ -72,6 +72,6 @@ pub fn op_secp256k1_verify(a: &mut Allocator, input: NodePtr, max_cost: Cost) ->
     if result.is_err() {
         err(input, "secp256k1_verify failed")
     } else {
-        Ok(Reduction(cost, a.null()))
+        Ok(Reduction(cost, a.nil()))
     }
 }

--- a/src/serde/de_br.rs
+++ b/src/serde/de_br.rs
@@ -20,7 +20,7 @@ pub fn node_from_stream_backrefs(
     allocator: &mut Allocator,
     f: &mut Cursor<&[u8]>,
 ) -> io::Result<NodePtr> {
-    let mut values = allocator.null();
+    let mut values = allocator.nil();
     let mut ops = vec![ParseOp::SExp];
 
     let mut b = [0; 1];

--- a/src/serde/object_cache.rs
+++ b/src/serde/object_cache.rs
@@ -254,7 +254,7 @@ fn test_very_long_list() {
 
     const LIST_SIZE: u64 = 20_000_000;
     let mut allocator = Allocator::new();
-    let mut top = allocator.null();
+    let mut top = allocator.nil();
     for _ in 0..LIST_SIZE {
         let atom = allocator.one();
         top = allocator.new_pair(atom, top).unwrap();

--- a/src/serde/parse_atom.rs
+++ b/src/serde/parse_atom.rs
@@ -82,7 +82,7 @@ pub fn parse_atom(
     if first_byte == 0x01 {
         Ok(allocator.one())
     } else if first_byte == 0x80 {
-        Ok(allocator.null())
+        Ok(allocator.nil())
     } else {
         let blob = parse_atom_ptr(f, first_byte)?;
         Ok(allocator.new_atom(blob)?)

--- a/src/serde/tools.rs
+++ b/src/serde/tools.rs
@@ -121,8 +121,8 @@ pub fn serialized_length_from_bytes(b: &[u8]) -> io::Result<u64> {
     // the allocator is just used to track the tree structure, in order to
     // validate back-references
     let mut allocator = Allocator::new();
-    let null = allocator.null();
-    let mut values = null;
+    let nil = allocator.nil();
+    let mut values = nil;
     let mut ops = vec![ParseOp::SExp];
 
     while let Some(op) = ops.pop() {
@@ -140,14 +140,14 @@ pub fn serialized_length_from_bytes(b: &[u8]) -> io::Result<u64> {
                 } else if b[0] == 0x80 || b[0] <= MAX_SINGLE_BYTE {
                     // This one byte we just read was the whole atom.
                     // or the special case of NIL
-                    values = allocator.new_pair(null, values)?;
+                    values = allocator.new_pair(nil, values)?;
                 } else {
                     let blob_size = decode_size(&mut f, b[0])?;
                     f.seek(SeekFrom::Current(blob_size as i64))?;
                     if (f.get_ref().len() as u64) < f.position() {
                         return Err(bad_encoding());
                     }
-                    values = allocator.new_pair(null, values)?;
+                    values = allocator.new_pair(nil, values)?;
                 }
             }
             ParseOp::Cons => {

--- a/src/test_ops.rs
+++ b/src/test_ops.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 
 fn parse_atom(a: &mut Allocator, v: &str) -> NodePtr {
     if v == "0" {
-        return a.null();
+        return a.nil();
     }
 
     assert!(!v.is_empty());
@@ -143,10 +143,10 @@ pub fn parse_list<'a>(a: &mut Allocator, v: &'a str) -> (NodePtr, &'a str) {
     let v = v.trim();
     let (first, rest) = pop_token(v);
     if first.is_empty() {
-        return (a.null(), rest);
+        return (a.nil(), rest);
     }
     if first == ")" {
-        return (a.null(), rest);
+        return (a.nil(), rest);
     }
     if first == "(" {
         let (head, new_rest) = parse_list(a, rest);
@@ -317,7 +317,7 @@ fn test_ops(#[case] filename: &str) {
 fn test_single_argument_raise_atom() {
     let mut allocator = Allocator::new();
     let a1 = allocator.new_atom(&[65]).unwrap();
-    let args = allocator.new_pair(a1, allocator.null()).unwrap();
+    let args = allocator.new_pair(a1, allocator.nil()).unwrap();
     let result = op_raise(&mut allocator, args, 100000);
     assert_eq!(result, Err(EvalErr(a1, "clvm raise".to_string())));
 }
@@ -328,11 +328,11 @@ fn test_single_argument_raise_pair() {
     let a1 = allocator.new_atom(&[65]).unwrap();
     let a2 = allocator.new_atom(&[66]).unwrap();
     // (a2)
-    let mut args = allocator.new_pair(a2, allocator.null()).unwrap();
+    let mut args = allocator.new_pair(a2, allocator.nil()).unwrap();
     // (a1 a2)
     args = allocator.new_pair(a1, args).unwrap();
     // ((a1 a2))
-    args = allocator.new_pair(args, allocator.null()).unwrap();
+    args = allocator.new_pair(args, allocator.nil()).unwrap();
     let result = op_raise(&mut allocator, args, 100000);
     assert_eq!(result, Err(EvalErr(args, "clvm raise".to_string())));
 }
@@ -343,7 +343,7 @@ fn test_multi_argument_raise() {
     let a1 = allocator.new_atom(&[65]).unwrap();
     let a2 = allocator.new_atom(&[66]).unwrap();
     // (a1)
-    let mut args = allocator.new_pair(a2, allocator.null()).unwrap();
+    let mut args = allocator.new_pair(a2, allocator.nil()).unwrap();
     // (a1 a2)
     args = allocator.new_pair(a1, args).unwrap();
     let result = op_raise(&mut allocator, args, 100000);
@@ -389,19 +389,19 @@ fn test_pre_eval_and_post_eval() {
     let a101 = allocator.new_atom(&[101]).unwrap();
 
     // (a (q . (f (c 2 5))) (q 99 101))
-    let arg_tail = allocator.new_pair(a101, allocator.null()).unwrap();
+    let arg_tail = allocator.new_pair(a101, allocator.nil()).unwrap();
     let arg_mid = allocator.new_pair(a99, arg_tail).unwrap();
     let args = allocator.new_pair(a1, arg_mid).unwrap();
 
-    let cons_tail = allocator.new_pair(a5, allocator.null()).unwrap();
+    let cons_tail = allocator.new_pair(a5, allocator.nil()).unwrap();
     let cons_args = allocator.new_pair(a2, cons_tail).unwrap();
     let cons_expr = allocator.new_pair(a4, cons_args).unwrap();
 
-    let f_tail = allocator.new_pair(cons_expr, allocator.null()).unwrap();
+    let f_tail = allocator.new_pair(cons_expr, allocator.nil()).unwrap();
     let f_expr = allocator.new_pair(a5, f_tail).unwrap();
     let f_quoted = allocator.new_pair(a1, f_expr).unwrap();
 
-    let a_tail = allocator.new_pair(args, allocator.null()).unwrap();
+    let a_tail = allocator.new_pair(args, allocator.nil()).unwrap();
     let a_args = allocator.new_pair(f_quoted, a_tail).unwrap();
     let program = allocator.new_pair(a2, a_args).unwrap();
 
@@ -443,12 +443,11 @@ fn test_pre_eval_and_post_eval() {
         Ok(Some(post_eval_f))
     });
 
-    let allocator_null = allocator.null();
     let result = run_program_with_pre_eval(
         &mut allocator,
         &ChiaDialect::new(NO_UNKNOWN_OPS),
         program,
-        allocator_null,
+        NodePtr::nil(),
         COST_LIMIT,
         Some(pre_eval_f),
     )
@@ -469,13 +468,13 @@ fn test_pre_eval_and_post_eval() {
     let args_consed = allocator.new_pair(a99, a101).unwrap();
 
     let mut desired_outcomes = Vec::new(); // Not in order.
-    desired_outcomes.push((args, allocator_null, arg_mid));
-    desired_outcomes.push((f_quoted, allocator_null, f_expr));
+    desired_outcomes.push((args, NodePtr::nil(), arg_mid));
+    desired_outcomes.push((f_quoted, NodePtr::nil(), f_expr));
     desired_outcomes.push((a2, arg_mid, a99));
     desired_outcomes.push((a5, arg_mid, a101));
     desired_outcomes.push((cons_expr, arg_mid, args_consed));
     desired_outcomes.push((f_expr, arg_mid, a99));
-    desired_outcomes.push((program, allocator_null, a99));
+    desired_outcomes.push((program, NodePtr::nil(), a99));
 
     let mut found_outcomes = HashSet::new();
     let tracking_examine = tracking.borrow();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -14,7 +14,7 @@ fn test_serialize_roundtrip(a: &mut Allocator, n: NodePtr) {
 #[test]
 fn test_roundtrip() {
     let mut a = Allocator::new();
-    let n = a.null();
+    let n = a.nil();
     test_serialize_roundtrip(&mut a, n);
 
     let n = a.one();
@@ -39,14 +39,14 @@ fn test_roundtrip() {
     test_serialize_roundtrip(&mut a, n);
 
     // deep tree
-    let mut prev = a.null();
+    let mut prev = a.nil();
     for _ in 0..=4000 {
         prev = a.new_pair(a.one(), prev).unwrap();
     }
     test_serialize_roundtrip(&mut a, prev);
 
     // deep reverse tree
-    let mut prev = a.null();
+    let mut prev = a.nil();
     for _ in 0..=4000 {
         let n = a.one();
         prev = a.new_pair(prev, n).unwrap();
@@ -58,8 +58,8 @@ fn test_roundtrip() {
 fn test_serialize_blobs() {
     let mut a = Allocator::new();
 
-    // null
-    let n = a.null();
+    // nil
+    let n = a.nil();
     assert_eq!(node_to_bytes(&a, n).unwrap(), &[0x80]);
 
     // one
@@ -86,8 +86,8 @@ fn test_serialize_blobs() {
 fn test_serialize_lists() {
     let mut a = Allocator::new();
 
-    // null
-    let n = a.null();
+    // nil
+    let n = a.nil();
     assert_eq!(node_to_bytes(&a, n).unwrap(), &[0x80]);
 
     // one item

--- a/src/traverse_path.rs
+++ b/src/traverse_path.rs
@@ -42,7 +42,7 @@ pub fn traverse_path(allocator: &Allocator, node_index: &[u8], args: NodePtr) ->
         + TRAVERSE_COST_PER_BIT;
 
     if first_bit_byte_index >= node_index.len() {
-        return Ok(Reduction(cost, allocator.null()));
+        return Ok(Reduction(cost, allocator.nil()));
     }
 
     // find first non-zero bit (the most significant bit is a sentinel)
@@ -105,7 +105,7 @@ fn test_traverse_path() {
     use crate::allocator::Allocator;
 
     let mut a = Allocator::new();
-    let nul = a.null();
+    let nul = a.nil();
     let n1 = a.new_atom(&[0, 1, 2]).unwrap();
     let n2 = a.new_atom(&[4, 5, 6]).unwrap();
 

--- a/tools/src/bin/benchmark-clvm-cost.rs
+++ b/tools/src/bin/benchmark-clvm-cost.rs
@@ -29,7 +29,7 @@ fn build_call(
     num: i32,
     extra: Option<NodePtr>,
 ) -> NodePtr {
-    let mut args = a.null();
+    let mut args = a.nil();
     for _i in 0..num {
         match arg {
             OpArgs::SingleArg(a1) => {
@@ -65,7 +65,7 @@ fn build_nested_call(
 ) -> NodePtr {
     let op_code = a.new_number(op.into()).unwrap();
     for _i in 0..num {
-        let mut args = a.null();
+        let mut args = a.nil();
         match arg {
             OpArgs::SingleArg(a1) => {
                 args = a.new_pair(a1, args).unwrap();
@@ -123,7 +123,7 @@ fn time_invocation(a: &mut Allocator, op: u32, arg: OpArgs, flags: u32) -> f64 {
     //println!("{:x?}", &Node::new(a, call));
     let dialect = ChiaDialect::new(ENABLE_BLS_OPS_OUTSIDE_GUARD);
     let start = Instant::now();
-    let r = run_program(a, &dialect, call, a.null(), 11000000000);
+    let r = run_program(a, &dialect, call, a.nil(), 11000000000);
     if (flags & ALLOW_FAILURE) == 0 {
         r.unwrap();
     }
@@ -188,7 +188,7 @@ fn time_per_arg(a: &mut Allocator, op: &Operator, output: &mut dyn Write) -> f64
         for i in 0..100 {
             let call = build_call(a, op.opcode, arg, i, op.extra);
             let start = Instant::now();
-            let r = run_program(a, &dialect, call, a.null(), 11000000000);
+            let r = run_program(a, &dialect, call, a.nil(), 11000000000);
             if (op.flags & ALLOW_FAILURE) == 0 {
                 r.unwrap();
             }
@@ -232,7 +232,7 @@ fn base_call_time(
             a.restore_checkpoint(&checkpoint);
             let call = build_nested_call(a, op.opcode, arg, i, op.extra);
             let start = Instant::now();
-            let r = run_program(a, &dialect, call, a.null(), 11000000000);
+            let r = run_program(a, &dialect, call, a.nil(), 11000000000);
             if (op.flags & ALLOW_FAILURE) == 0 {
                 r.unwrap();
             }


### PR DESCRIPTION
also the utility function to test if a `NodePtr` is the empty atom is renamed from `nullp()` ->`nilp()`.
we still have `nullp()` in the python bindings.