### PR TITLE
remove NodePtr hack and fix-up benchmark-clvm-cost

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -25,11 +25,6 @@ impl NodePtr {
         NodePtr(((t as u32) << NODE_PTR_IDX_BITS) | (idx as u32))
     }
 
-    // TODO: remove this
-    pub fn hack(val: usize) -> Self {
-        Self::new(ObjectType::Bytes, val)
-    }
-
     fn node_type(&self) -> (ObjectType, usize) {
         (
             match self.0 >> NODE_PTR_IDX_BITS {


### PR DESCRIPTION
This fixes `benchmark-clvm-cost` to not need a magic `NodePtr` value for a variable placeholder. Instead, it uses `Option<NodePtr>` as it should have.

This let us remove the `NodePtr::hack()` constructor.