### PR TITLE
Custom Atom type to replace unsound API

### DIFF
--- a/fuzz/fuzz_targets/deserialize_br_rand_tree.rs
+++ b/fuzz/fuzz_targets/deserialize_br_rand_tree.rs
@@ -6,7 +6,6 @@ use clvmr::allocator::Allocator;
 use clvmr::serde::node_from_bytes_backrefs;
 use clvmr::serde::node_to_bytes_backrefs;
 use libfuzzer_sys::fuzz_target;
-//use fuzzing_utils;
 
 fn do_fuzz(data: &[u8], short_atoms: bool) {
     let mut allocator = Allocator::new();

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -2,7 +2,6 @@ use crate::err_utils::err;
 use crate::number::{node_from_number, number_from_u8, Number};
 use crate::reduction::EvalErr;
 use chia_bls::{G1Element, G2Element};
-use std::cell::RefCell;
 
 const MAX_NUM_ATOMS: usize = 62500000;
 const MAX_NUM_PAIRS: usize = 62500000;
@@ -198,11 +197,6 @@ impl Allocator {
     pub fn new_limited(heap_limit: usize) -> Self {
         // we have a maximum of 4 GiB heap, because pointers are 32 bit unsigned
         assert!(heap_limit <= u32::MAX as usize);
-
-        let mut temp_vec = Vec::<RefCell<[u8; 4]>>::with_capacity(64);
-        for _ in 0..16 {
-            temp_vec.push(RefCell::default());
-        }
 
         let mut r = Self {
             u8_vec: Vec::new(),

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -126,6 +126,12 @@ impl<'a> AsRef<[u8]> for Atom<'a> {
     }
 }
 
+impl<'a> Borrow<[u8]> for Atom<'a> {
+    fn borrow(&self) -> &[u8] {
+        self.as_ref()
+    }
+}
+
 #[derive(Debug)]
 pub struct Allocator {
     // this is effectively a grow-only stack where atoms are allocated. Atoms
@@ -1350,6 +1356,7 @@ fn test_g2_roundtrip(#[case] atom: &str) {
 
 #[cfg(test)]
 use core::convert::TryFrom;
+use std::borrow::Borrow;
 
 #[cfg(test)]
 type MakeFun = fn(&mut Allocator, &[u8]) -> NodePtr;

--- a/src/bls_ops.rs
+++ b/src/bls_ops.rs
@@ -308,7 +308,7 @@ pub fn op_bls_verify(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Respo
     // followed by a variable number of (G1, msg)-pairs (as a flat list)
     args = rest(a, args)?;
 
-    let mut items = Vec::<(PublicKey, Vec<u8>)>::new();
+    let mut items = Vec::<(PublicKey, Atom)>::new();
     while !nilp(a, args) {
         let pk = a.g1(first(a, args)?)?;
         args = rest(a, args)?;
@@ -320,7 +320,7 @@ pub fn op_bls_verify(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Respo
         cost += DST_G2.len() as Cost * BLS_MAP_TO_G2_COST_PER_DST_BYTE;
         check_cost(a, cost, max_cost)?;
 
-        items.push((pk, msg.as_ref().to_vec()));
+        items.push((pk, msg));
     }
 
     if !aggregate_verify(&signature, items) {

--- a/src/bls_ops.rs
+++ b/src/bls_ops.rs
@@ -1,4 +1,4 @@
-use crate::allocator::{Allocator, NodePtr};
+use crate::allocator::{Allocator, Atom, NodePtr};
 use crate::cost::{check_cost, Cost};
 use crate::err_utils::err;
 use crate::op_utils::{
@@ -97,12 +97,13 @@ pub fn op_bls_g1_negate(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> R
     let blob = atom(a, point, "G1 atom")?;
     // this is here to validate the point
     let _g1 = G1Element::from_bytes(
-        blob.try_into()
+        blob.as_ref()
+            .try_into()
             .map_err(|_| EvalErr(point, "atom is not G1 size, 48 bytes".to_string()))?,
     )
     .map_err(|_| EvalErr(point, "atom is not a valid G1 point".to_string()))?;
 
-    if (blob[0] & 0xe0) == 0xc0 {
+    if (blob.as_ref()[0] & 0xe0) == 0xc0 {
         // This is compressed infinity. negating it is a no-op
         // we can just pass through the same atom as we received. We'll charge
         // the allocation cost anyway, for consistency
@@ -111,7 +112,7 @@ pub fn op_bls_g1_negate(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> R
             point,
         ))
     } else {
-        let mut blob: [u8; 48] = blob.try_into().unwrap();
+        let mut blob: [u8; 48] = blob.as_ref().try_into().unwrap();
         blob[0] ^= 0x20;
         new_atom_and_cost(a, BLS_G1_NEGATE_BASE_COST, &blob)
     }
@@ -182,11 +183,13 @@ pub fn op_bls_g2_negate(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> R
 
     // we don't validate the point. We may want to soft fork-in validating the
     // point once the allocator preserves native representation of points
-    let blob = atom(a, point, "G2 atom")?;
+    let blob_atom = atom(a, point, "G2 atom")?;
+    let blob = blob_atom.as_ref();
 
     // this is here to validate the point
     let _g2 = G2Element::from_bytes(
-        blob.try_into()
+        blob.as_ref()
+            .try_into()
             .map_err(|_| EvalErr(point, "atom is not G2 size, 96 bytes".to_string()))?,
     )
     .map_err(|_| EvalErr(point, "atom is not a valid G2 point".to_string()))?;
@@ -200,7 +203,7 @@ pub fn op_bls_g2_negate(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> R
             point,
         ))
     } else {
-        let mut blob: [u8; 96] = blob.try_into().unwrap();
+        let mut blob: [u8; 96] = blob.as_ref().try_into().unwrap();
         blob[0] ^= 0x20;
         new_atom_and_cost(a, BLS_G2_NEGATE_BASE_COST, &blob)
     }
@@ -215,19 +218,19 @@ pub fn op_bls_map_to_g1(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Re
     check_cost(a, cost, max_cost)?;
 
     let msg = atom(a, msg, "g1_map")?;
-    cost += msg.len() as Cost * BLS_MAP_TO_G1_COST_PER_BYTE;
+    cost += msg.as_ref().len() as Cost * BLS_MAP_TO_G1_COST_PER_BYTE;
     check_cost(a, cost, max_cost)?;
 
-    let dst: &[u8] = if argc == 2 {
+    let dst = if argc == 2 {
         atom(a, dst, "g1_map")?
     } else {
-        b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_AUG_"
+        Atom::Borrowed(b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_AUG_".as_slice())
     };
 
-    cost += dst.len() as Cost * BLS_MAP_TO_G1_COST_PER_DST_BYTE;
+    cost += dst.as_ref().len() as Cost * BLS_MAP_TO_G1_COST_PER_DST_BYTE;
     check_cost(a, cost, max_cost)?;
 
-    let point = hash_to_g1_with_dst(msg, dst);
+    let point = hash_to_g1_with_dst(msg.as_ref(), dst.as_ref());
     Ok(Reduction(
         cost + 48 * MALLOC_COST_PER_BYTE,
         a.new_g1(point)?,
@@ -243,18 +246,18 @@ pub fn op_bls_map_to_g2(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Re
     check_cost(a, cost, max_cost)?;
 
     let msg = atom(a, msg, "g2_map")?;
-    cost += msg.len() as Cost * BLS_MAP_TO_G2_COST_PER_BYTE;
+    cost += msg.as_ref().len() as Cost * BLS_MAP_TO_G2_COST_PER_BYTE;
 
-    let dst: &[u8] = if argc == 2 {
+    let dst = if argc == 2 {
         atom(a, dst, "g2_map")?
     } else {
-        DST_G2
+        Atom::Borrowed(DST_G2.as_slice())
     };
 
-    cost += dst.len() as Cost * BLS_MAP_TO_G2_COST_PER_DST_BYTE;
+    cost += dst.as_ref().len() as Cost * BLS_MAP_TO_G2_COST_PER_DST_BYTE;
     check_cost(a, cost, max_cost)?;
 
-    let point = hash_to_g2_with_dst(msg, dst);
+    let point = hash_to_g2_with_dst(msg.as_ref(), dst.as_ref());
     Ok(Reduction(
         cost + 96 * MALLOC_COST_PER_BYTE,
         a.new_g2(point)?,
@@ -305,7 +308,7 @@ pub fn op_bls_verify(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Respo
     // followed by a variable number of (G1, msg)-pairs (as a flat list)
     args = rest(a, args)?;
 
-    let mut items = Vec::<(PublicKey, &[u8])>::new();
+    let mut items = Vec::<(PublicKey, Vec<u8>)>::new();
     while !nilp(a, args) {
         let pk = a.g1(first(a, args)?)?;
         args = rest(a, args)?;
@@ -313,11 +316,11 @@ pub fn op_bls_verify(a: &mut Allocator, input: NodePtr, max_cost: Cost) -> Respo
         args = rest(a, args)?;
 
         cost += BLS_PAIRING_COST_PER_ARG;
-        cost += msg.len() as Cost * BLS_MAP_TO_G2_COST_PER_BYTE;
+        cost += msg.as_ref().len() as Cost * BLS_MAP_TO_G2_COST_PER_BYTE;
         cost += DST_G2.len() as Cost * BLS_MAP_TO_G2_COST_PER_DST_BYTE;
         check_cost(a, cost, max_cost)?;
 
-        items.push((pk, msg));
+        items.push((pk, msg.as_ref().to_vec()));
     }
 
     if !aggregate_verify(&signature, items) {

--- a/src/chia_dialect.rs
+++ b/src/chia_dialect.rs
@@ -84,7 +84,7 @@ impl Dialect for ChiaDialect {
             //                cost_function
 
             let b = allocator.atom(o);
-            let opcode = u32::from_be_bytes(b.try_into().unwrap());
+            let opcode = u32::from_be_bytes(b.as_ref().try_into().unwrap());
 
             // the secp operators have a fixed cost of 1850000 and 1300000,
             // which makes the multiplier 0x1c3a8f and 0x0cf84f (there is an

--- a/src/more_ops.rs
+++ b/src/more_ops.rs
@@ -187,7 +187,8 @@ pub fn op_unknown(
     // this means that unknown ops where cost_function is 1, 2, or 3, may still be
     // fatal errors if the arguments passed are not atoms.
 
-    let op = allocator.atom(o);
+    let op_atom = allocator.atom(o);
+    let op = op_atom.as_ref();
 
     if op.is_empty() || (op.len() >= 2 && op[0] == 0xff && op[1] == 0xff) {
         return err(o, "reserved operator");
@@ -346,7 +347,7 @@ pub fn op_sha256(a: &mut Allocator, mut input: NodePtr, max_cost: Cost) -> Respo
             max_cost,
         )?;
         let blob = atom(a, arg, "sha256")?;
-        byte_count += blob.len();
+        byte_count += blob.as_ref().len();
         hasher.update(blob);
     }
     cost += byte_count as Cost * SHA256_COST_PER_BYTE;
@@ -543,8 +544,10 @@ pub fn op_gr(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
 
 pub fn op_gr_bytes(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     let [n0, n1] = get_args::<2>(a, input, ">s")?;
-    let v0 = atom(a, n0, ">s")?;
-    let v1 = atom(a, n1, ">s")?;
+    let v0_atom = atom(a, n0, ">s")?;
+    let v1_atom = atom(a, n1, ">s")?;
+    let v0 = v0_atom.as_ref();
+    let v1 = v1_atom.as_ref();
     let cost = GRS_BASE_COST + (v0.len() + v1.len()) as Cost * GRS_COST_PER_BYTE;
     Ok(Reduction(cost, if v0 > v1 { a.one() } else { a.nil() }))
 }
@@ -654,7 +657,7 @@ fn test_op_ash() {
     );
 
     let node = test_shift(op_ash, &mut a, &[1], &[0x80, 0]).unwrap().1;
-    assert_eq!(a.atom(node), &[]);
+    assert_eq!(a.atom(node).as_ref(), &[]);
 
     assert_eq!(
         test_shift(op_ash, &mut a, &[1], &[0x7f, 0, 0, 0])
@@ -672,14 +675,16 @@ fn test_op_ash() {
 
     let node = test_shift(op_ash, &mut a, &[1], &[0x7f, 0]).unwrap().1;
     // the result is 1 followed by 4064 zeroes
-    let node = a.atom(node);
-    assert_eq!(node[0], 1);
-    assert_eq!(node.len(), 4065);
+    let node_atom = a.atom(node);
+    let node_bytes = node_atom.as_ref();
+    assert_eq!(node_bytes[0], 1);
+    assert_eq!(node_bytes.len(), 4065);
 }
 
 pub fn op_lsh(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     let [n0, n1] = get_args::<2>(a, input, "lsh")?;
-    let b0 = atom(a, n0, "lsh")?;
+    let b0_atom = atom(a, n0, "lsh")?;
+    let b0 = b0_atom.as_ref();
     let a1 = i32_atom(a, n1, "lsh")?;
     if !(-65535..=65535).contains(&a1) {
         return err(n1, "shift too large");
@@ -715,7 +720,7 @@ fn test_op_lsh() {
     );
 
     let node = test_shift(op_lsh, &mut a, &[1], &[0x80, 0]).unwrap().1;
-    assert_eq!(a.atom(node), &[]);
+    assert_eq!(a.atom(node).as_ref(), &[]);
 
     assert_eq!(
         test_shift(op_lsh, &mut a, &[1], &[0x7f, 0, 0, 0])
@@ -733,9 +738,10 @@ fn test_op_lsh() {
 
     let node = test_shift(op_lsh, &mut a, &[1], &[0x7f, 0]).unwrap().1;
     // the result is 1 followed by 4064 zeroes
-    let node = a.atom(node);
-    assert_eq!(node[0], 1);
-    assert_eq!(node.len(), 4065);
+    let node_atom = a.atom(node);
+    let node_bytes = node_atom.as_ref();
+    assert_eq!(node_bytes[0], 1);
+    assert_eq!(node_bytes.len(), 4065);
 }
 
 fn binop_reduction(
@@ -863,14 +869,15 @@ pub fn op_coinid(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response
     let [parent_coin, puzzle_hash, amount] = get_args::<3>(a, input, "coinid")?;
 
     let parent_coin = atom(a, parent_coin, "coinid")?;
-    if parent_coin.len() != 32 {
+    if parent_coin.as_ref().len() != 32 {
         return err(input, "coinid: invalid parent coin id (must be 32 bytes)");
     }
     let puzzle_hash = atom(a, puzzle_hash, "coinid")?;
-    if puzzle_hash.len() != 32 {
+    if puzzle_hash.as_ref().len() != 32 {
         return err(input, "coinid: invalid puzzle hash (must be 32 bytes)");
     }
-    let amount = atom(a, amount, "coinid")?;
+    let amount_atom = atom(a, amount, "coinid")?;
+    let amount = amount_atom.as_ref();
     if !amount.is_empty() {
         if (amount[0] & 0x80) != 0 {
             return err(input, "coinid: invalid amount (may not be negative");

--- a/src/number.rs
+++ b/src/number.rs
@@ -41,56 +41,56 @@ fn test_node_from_number() {
     let num = number_from_u8(&[0]);
     let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "0");
-    assert_eq!(a.atom(ptr).len(), 0);
+    assert_eq!(a.atom(ptr).as_ref().len(), 0);
 
     let num = number_from_u8(&[1]);
     let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "1");
-    assert_eq!(&[1], &a.atom(ptr));
+    assert_eq!(&[1], &a.atom(ptr).as_ref());
 
     // leading zeroes are redundant
     let num = number_from_u8(&[0, 0, 0, 1]);
     let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "1");
-    assert_eq!(&[1], &a.atom(ptr));
+    assert_eq!(&[1], &a.atom(ptr).as_ref());
 
     let num = number_from_u8(&[0x00, 0x00, 0x80]);
     let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "128");
-    assert_eq!(&[0x00, 0x80], &a.atom(ptr));
+    assert_eq!(&[0x00, 0x80], &a.atom(ptr).as_ref());
 
     // A leading zero is necessary to encode a positive number with the
     // penultimate byte's most significant bit set
     let num = number_from_u8(&[0x00, 0xff]);
     let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "255");
-    assert_eq!(&[0x00, 0xff], &a.atom(ptr));
+    assert_eq!(&[0x00, 0xff], &a.atom(ptr).as_ref());
 
     let num = number_from_u8(&[0x7f, 0xff]);
     let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "32767");
-    assert_eq!(&[0x7f, 0xff], &a.atom(ptr));
+    assert_eq!(&[0x7f, 0xff], &a.atom(ptr).as_ref());
 
     // the first byte is redundant, it's still -1
     let num = number_from_u8(&[0xff, 0xff]);
     let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "-1");
-    assert_eq!(&[0xff], &a.atom(ptr));
+    assert_eq!(&[0xff], &a.atom(ptr).as_ref());
 
     let num = number_from_u8(&[0xff]);
     let ptr = node_from_number(&mut a, &num).unwrap();
     assert_eq!(format!("{}", num), "-1");
-    assert_eq!(&[0xff], &a.atom(ptr));
+    assert_eq!(&[0xff], &a.atom(ptr).as_ref());
 
     let num = number_from_u8(&[0x00, 0x80, 0x00]);
     assert_eq!(format!("{}", num), "32768");
     let ptr = node_from_number(&mut a, &num).unwrap();
-    assert_eq!(&[0x00, 0x80, 0x00], &a.atom(ptr));
+    assert_eq!(&[0x00, 0x80, 0x00], &a.atom(ptr).as_ref());
 
     let num = number_from_u8(&[0x00, 0x40, 0x00]);
     assert_eq!(format!("{}", num), "16384");
     let ptr = node_from_number(&mut a, &num).unwrap();
-    assert_eq!(&[0x40, 0x00], &a.atom(ptr));
+    assert_eq!(&[0x40, 0x00], &a.atom(ptr).as_ref());
 }
 
 #[cfg(test)]

--- a/src/op_utils.rs
+++ b/src/op_utils.rs
@@ -1,4 +1,4 @@
-use crate::allocator::{Allocator, NodePtr, NodeVisitor, SExp};
+use crate::allocator::{Allocator, Atom, NodePtr, NodeVisitor, SExp};
 use crate::cost::Cost;
 use crate::err_utils::err;
 use crate::number::Number;
@@ -405,11 +405,11 @@ fn test_uint_atom_8_pair() {
     assert!(uint_atom::<8>(&a, p, "test") == err(p, "test requires int arg"));
 }
 
-pub fn atom<'a>(a: &'a Allocator, n: NodePtr, op_name: &str) -> Result<&'a [u8], EvalErr> {
-    match a.sexp(n) {
-        SExp::Atom => Ok(a.atom(n)),
-        _ => err(n, &format!("{op_name} on list")),
+pub fn atom<'a>(a: &'a Allocator, n: NodePtr, op_name: &str) -> Result<Atom<'a>, EvalErr> {
+    if n.is_pair() {
+        return err(n, &format!("{op_name} on list"));
     }
+    Ok(a.atom(n))
 }
 
 fn u32_from_u8_impl(buf: &[u8], signed: bool) -> Option<u32> {

--- a/src/runtime_dialect.rs
+++ b/src/runtime_dialect.rs
@@ -42,7 +42,9 @@ impl Dialect for RuntimeDialect {
         max_cost: Cost,
         _extensions: OperatorSet,
     ) -> Response {
-        let b = &allocator.atom(o);
+        let atom = allocator.atom(o);
+        let b = atom.as_ref();
+
         if b.len() == 1 {
             if let Some(f) = self.f_lookup[b[0] as usize] {
                 return f(allocator, argument_list, max_cost);

--- a/src/secp_ops.rs
+++ b/src/secp_ops.rs
@@ -19,22 +19,22 @@ pub fn op_secp256r1_verify(a: &mut Allocator, input: NodePtr, max_cost: Cost) ->
 
     // first argument is sec1 encoded pubkey
     let pubkey = atom(a, pubkey, "secp256r1_verify pubkey")?;
-    let verifier = P1VerifyingKey::from_sec1_bytes(pubkey)
+    let verifier = P1VerifyingKey::from_sec1_bytes(pubkey.as_ref())
         .or_else(|_| err(input, "secp256r1_verify pubkey is not valid"))?;
 
     // second arg is sha256 hash of message
     let msg = atom(a, msg, "secp256r1_verify msg")?;
-    if msg.len() != 32 {
+    if msg.as_ref().len() != 32 {
         return err(input, "secp256r1_verify message digest is not 32 bytes");
     }
 
     // third arg is a fixed-size signature
     let sig = atom(a, sig, "secp256r1_verify sig")?;
-    let sig = P1Signature::from_slice(sig)
+    let sig = P1Signature::from_slice(sig.as_ref())
         .or_else(|_| err(input, "secp256r1_verify sig is not valid"))?;
 
     // verify signature
-    let result = verifier.verify_prehash(msg, &sig);
+    let result = verifier.verify_prehash(msg.as_ref(), &sig);
 
     if result.is_err() {
         err(input, "secp256r1_verify failed")
@@ -52,22 +52,22 @@ pub fn op_secp256k1_verify(a: &mut Allocator, input: NodePtr, max_cost: Cost) ->
 
     // first argument is sec1 encoded pubkey
     let pubkey = atom(a, pubkey, "secp256k1_verify pubkey")?;
-    let verifier = K1VerifyingKey::from_sec1_bytes(pubkey)
+    let verifier = K1VerifyingKey::from_sec1_bytes(pubkey.as_ref())
         .or_else(|_| err(input, "secp256k1_verify pubkey is not valid"))?;
 
     // second arg is message
     let msg = atom(a, msg, "secp256k1_verify msg")?;
-    if msg.len() != 32 {
+    if msg.as_ref().len() != 32 {
         return err(input, "secp256k1_verify message digest is not 32 bytes");
     }
 
     // third arg is a fixed-size signature
     let sig = atom(a, sig, "secp256k1_verify sig")?;
-    let sig = K1Signature::from_slice(sig)
+    let sig = K1Signature::from_slice(sig.as_ref())
         .or_else(|_| err(input, "secp256k1_verify sig is not valid"))?;
 
     // verify signature
-    let result = verifier.verify_prehash(msg, &sig);
+    let result = verifier.verify_prehash(msg.as_ref(), &sig);
 
     if result.is_err() {
         err(input, "secp256k1_verify failed")

--- a/src/serde/object_cache.rs
+++ b/src/serde/object_cache.rs
@@ -45,7 +45,7 @@ impl<'a, T: Clone> ObjectCache<'a, T> {
 
     /// return the cached value for this node, or `None`
     fn get_from_cache(&self, node: &NodePtr) -> Option<&T> {
-        let index = node.as_index();
+        let index = node.as_unique_index();
         if index < self.cache.len() {
             self.cache[index].as_ref()
         } else {
@@ -55,7 +55,7 @@ impl<'a, T: Clone> ObjectCache<'a, T> {
 
     /// set the cached value for a node
     fn set(&mut self, node: &NodePtr, v: T) {
-        let index = node.as_index();
+        let index = node.as_unique_index();
         if index >= self.cache.len() {
             self.cache.resize(index + 1, None);
         }
@@ -102,7 +102,7 @@ pub fn treehash(
                 .get_from_cache(&right)
                 .map(|right_value| hash_blobs(&[&[2], left_value, right_value])),
         },
-        SExp::Atom => Some(hash_blobs(&[&[1], allocator.atom(node)])),
+        SExp::Atom => Some(hash_blobs(&[&[1], allocator.atom(node).as_ref()])),
     }
 }
 
@@ -125,8 +125,8 @@ pub fn serialized_length(
         },
         SExp::Atom => {
             let buf = allocator.atom(node);
-            let lb: u64 = buf.len().try_into().unwrap_or(u64::MAX);
-            Some(if lb == 0 || (lb == 1 && buf[0] < 128) {
+            let lb: u64 = buf.as_ref().len().try_into().unwrap_or(u64::MAX);
+            Some(if lb == 0 || (lb == 1 && buf.as_ref()[0] < 128) {
                 1
             } else if lb < 0x40 {
                 1 + lb

--- a/src/serde/parse_atom.rs
+++ b/src/serde/parse_atom.rs
@@ -190,9 +190,9 @@ fn check_parse_atom(blob: &[u8], expected_atom: &[u8]) {
     let mut allocator = Allocator::new();
     let atom_node = parse_atom(&mut allocator, first, &mut cursor).unwrap();
 
-    let atom_ptr = allocator.atom(atom_node);
+    let atom = allocator.atom(atom_node);
 
-    assert_eq!(expected_atom, atom_ptr);
+    assert_eq!(expected_atom, atom.as_ref());
 }
 
 #[cfg(test)]

--- a/src/serde/ser_br.rs
+++ b/src/serde/ser_br.rs
@@ -64,7 +64,7 @@ pub fn node_to_stream_backrefs<W: io::Write>(
                 }
                 SExp::Atom => {
                     let atom = allocator.atom(node_to_write);
-                    write_atom(f, atom)?;
+                    write_atom(f, atom.as_ref())?;
                     read_cache_lookup.push(*node_tree_hash);
                 }
             },

--- a/wasm/src/lazy_node.rs
+++ b/wasm/src/lazy_node.rs
@@ -31,7 +31,7 @@ impl LazyNode {
     #[wasm_bindgen(getter)]
     pub fn atom(&self) -> Option<Vec<u8>> {
         match &self.allocator.sexp(self.node) {
-            SExp::Atom => Some(self.allocator.atom(self.node).into()),
+            SExp::Atom => Some(self.allocator.atom(self.node).as_ref().into()),
             _ => None,
         }
     }

--- a/wheel/src/lazy_node.rs
+++ b/wheel/src/lazy_node.rs
@@ -37,7 +37,7 @@ impl LazyNode {
     #[getter(atom)]
     pub fn atom(&self, py: Python) -> Option<PyObject> {
         match &self.allocator.sexp(self.node) {
-            SExp::Atom => Some(PyBytes::new(py, self.allocator.atom(self.node)).into()),
+            SExp::Atom => Some(PyBytes::new(py, self.allocator.atom(self.node).as_ref()).into()),
             _ => None,
         }
     }


### PR DESCRIPTION
This PR changes the way `a.atom(ptr)` works to return an `Atom` type that can convert small integers to byte slices. This prevents a memory safety issue on the edge case where you exceed the temp vec length and references are left dangling.

Overall, the performance is actually improved slightly for the majority of benchmarks.

```
group                                                          after                                before
-----                                                          -------                                ------
deserialize/node_from_bytes                                    1.03    119.7±2.17µs        ? ?/sec    1.00    116.6±0.82µs        ? ?/sec
deserialize/node_from_bytes_backrefs                           1.00    141.8±4.51µs        ? ?/sec    1.19    168.8±1.96µs        ? ?/sec
deserialize/node_from_bytes_backrefs-compressed                1.00    144.6±4.76µs        ? ?/sec    1.00    144.5±7.68µs        ? ?/sec
deserialize/serialized_length_from_bytes                       1.03     98.8±2.57µs        ? ?/sec    1.00     95.9±1.70µs        ? ?/sec
deserialize/serialized_length_from_bytes-compressed            1.00    112.2±2.75µs        ? ?/sec    1.00    112.3±0.85µs        ? ?/sec
deserialize/serialized_length_from_bytes_trusted               1.03     27.2±0.99µs        ? ?/sec    1.00     26.5±0.05µs        ? ?/sec
deserialize/serialized_length_from_bytes_trusted-compressed    1.14     25.4±5.93µs        ? ?/sec    1.00     22.3±0.51µs        ? ?/sec
deserialize/tree_hash_from_stream                              1.02      2.0±0.02ms        ? ?/sec    1.00   1975.8±4.71µs        ? ?/sec
run_program/block-2000                                         1.01     99.1±1.26ns        ? ?/sec    1.00     98.2±0.39ns        ? ?/sec
run_program/compressed-2000                                    1.00    353.8±4.83ms        ? ?/sec    1.08    381.5±2.64ms        ? ?/sec
run_program/concat                                             1.00    262.1±2.85ms        ? ?/sec    1.00    261.1±1.98ms        ? ?/sec
run_program/count-even                                         1.00      5.6±0.04ms        ? ?/sec    1.05      5.9±0.01ms        ? ?/sec
run_program/factorial                                          1.00    106.5±0.05ms        ? ?/sec    1.01    107.2±0.31ms        ? ?/sec
run_program/hash-string                                        1.00    215.9±0.21ns        ? ?/sec    1.00    215.6±0.88ns        ? ?/sec
run_program/hash-tree                                          1.00     16.8±0.06ms        ? ?/sec    1.05     17.7±0.87ms        ? ?/sec
run_program/large-block                                        1.00     87.1±0.41ms        ? ?/sec    1.00     86.8±0.03ms        ? ?/sec
run_program/loop_add                                           1.00  1311.2±37.06ms        ? ?/sec    1.05   1380.9±3.58ms        ? ?/sec
run_program/loop_ior                                           1.00  1254.7±10.61ms        ? ?/sec    1.18   1482.9±3.57ms        ? ?/sec
run_program/loop_not                                           1.00  1283.7±10.03ms        ? ?/sec    1.07  1372.0±11.66ms        ? ?/sec
run_program/loop_sub                                           1.00  1403.8±29.64ms        ? ?/sec    1.03   1450.4±6.99ms        ? ?/sec
run_program/loop_xor                                           1.00  1372.0±18.20ms        ? ?/sec    1.06  1459.6±15.68ms        ? ?/sec
run_program/matrix-multiply                                    1.00     96.2±3.67ms        ? ?/sec    1.00     96.6±0.32ms        ? ?/sec
run_program/point-pow                                          1.00    135.9±0.56ms        ? ?/sec    1.00    136.3±1.38ms        ? ?/sec
run_program/pubkey-tree                                        1.00     73.5±0.47ms        ? ?/sec    1.01     74.1±0.88ms        ? ?/sec
run_program/shift-left                                         1.02   1067.5±6.91ms        ? ?/sec    1.00   1051.2±4.25ms        ? ?/sec
run_program/substr                                             1.00      2.9±0.03ms        ? ?/sec    1.09      3.2±0.02ms        ? ?/sec
run_program/substr-tree                                        1.00     64.3±1.46ms        ? ?/sec    1.05     67.4±0.42ms        ? ?/sec
run_program/sum-tree                                           1.00    142.7±1.79ms        ? ?/sec    1.05    150.1±1.01ms        ? ?/sec
```