### PR TITLE
minor refactoring of a test in `de_br.rs`

### DIFF
--- a/src/serde/de_br.rs
+++ b/src/serde/de_br.rs
@@ -67,24 +67,21 @@ pub fn node_from_bytes_backrefs(allocator: &mut Allocator, b: &[u8]) -> io::Resu
 #[cfg(test)]
 use hex::FromHex;
 
-#[cfg(test)]
-use crate::serde::object_cache::{treehash, ObjectCache};
-
-#[cfg(test)]
-fn deserialize_check(serialization_as_hex: &str, expected_hash_as_hex: &str) {
-    let buf = Vec::from_hex(serialization_as_hex).unwrap();
-    let mut allocator = Allocator::new();
-    let node = node_from_bytes_backrefs(&mut allocator, &buf).unwrap();
-
-    let mut oc = ObjectCache::new(&allocator, treehash);
-    let calculated_hash = oc.get_or_calculate(&node).unwrap();
-    let ch: &[u8] = calculated_hash;
-    let expected_hash: Vec<u8> = Vec::from_hex(expected_hash_as_hex).unwrap();
-    assert_eq!(expected_hash, ch);
-}
-
 #[test]
 fn test_deserialize_with_backrefs() {
+    fn deserialize_check(serialization_as_hex: &str, expected_hash_as_hex: &str) {
+        use crate::serde::object_cache::{treehash, ObjectCache};
+        let buf = Vec::from_hex(serialization_as_hex).unwrap();
+        let mut allocator = Allocator::new();
+        let node = node_from_bytes_backrefs(&mut allocator, &buf).unwrap();
+
+        let mut oc = ObjectCache::new(&allocator, treehash);
+        let calculated_hash = oc.get_or_calculate(&node).unwrap();
+        let ch: &[u8] = calculated_hash;
+        let expected_hash: Vec<u8> = Vec::from_hex(expected_hash_as_hex).unwrap();
+        assert_eq!(expected_hash, ch);
+    }
+
     // ("foobar" "foobar")
     deserialize_check(
         "ff86666f6f626172ff86666f6f62617280",


### PR DESCRIPTION
Moving the helper function into the scope of the test that uses it clears up the file-scope. In a future patch I intend to introduce a similar kind of test that otherwise also would want to claim the name `deserialize_check`