### PR TITLE
improve fidelity of check if atom fits in `SmallAtom`

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -190,8 +190,9 @@ jobs:
         with:
           fetch-depth: 1
       - name: Install rust
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@master
         with:
+            toolchain: nightly-2024-02-11
             components: rustfmt, clippy
       - name: fmt
         run: |
@@ -202,14 +203,14 @@ jobs:
           cd fuzz
           cargo clippy
       - name: cargo-fuzz
-        run: cargo +nightly install cargo-fuzz
+        run: cargo install cargo-fuzz
       # TODO: it would be nice to save and restore the corpus between runs
       - name: build corpus
         run: |
           cd tools
           cargo run --bin generate-fuzz-corpus
       - name: build
-        run: cargo fuzz list | xargs -I "%" sh -c "cargo +nightly fuzz run % -- -max_total_time=30 || exit 255"
+        run: cargo fuzz list | xargs -I "%" sh -c "cargo fuzz run % -- -max_total_time=30 || exit 255"
 
   unit_tests:
     name: Unit tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ counters = []
 pre-eval = []
 
 [profile.release]
-lto = true
+lto = "thin"
 
 [dependencies]
 lazy_static = "1.4.0"

--- a/fuzz/fuzz_targets/allocator.rs
+++ b/fuzz/fuzz_targets/allocator.rs
@@ -1,6 +1,7 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 
+use clvmr::allocator::fits_in_small_atom;
 use clvmr::{Allocator, NodePtr};
 
 fn run_tests(a: &mut Allocator, atom1: NodePtr, data: &[u8]) {
@@ -21,6 +22,11 @@ fn run_tests(a: &mut Allocator, atom1: NodePtr, data: &[u8]) {
         assert_eq!(a.number(atom2), val.into());
         assert_eq!(a.atom_len(atom2), data.len());
         assert!(canonical);
+        assert_eq!(fits_in_small_atom(data), Some(val));
+    } else {
+        assert_eq!(fits_in_small_atom(data), None);
+        let val = a.number(atom1);
+        assert!(!canonical || val < 0.into() || val > ((1 << 26) - 1).into());
     }
 
     // number

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -53,16 +53,6 @@ impl NodePtr {
     fn index(self) -> u32 {
         self.0 & NODE_PTR_IDX_MASK
     }
-
-    pub(crate) fn as_unique_index(self) -> usize {
-        let value = self.index();
-
-        match self.object_type() {
-            ObjectType::Pair => (value as usize) * 3,
-            ObjectType::Bytes => (value as usize) * 3 + 1,
-            ObjectType::SmallAtom => (value as usize) * 3 + 2,
-        }
-    }
 }
 
 impl Default for NodePtr {
@@ -648,19 +638,6 @@ impl Allocator {
     pub fn heap_size(&self) -> usize {
         self.u8_vec.len()
     }
-}
-
-#[test]
-fn test_node_as_index() {
-    assert_eq!(NodePtr::new(ObjectType::Pair, 0).as_unique_index(), 0);
-    assert_eq!(NodePtr::new(ObjectType::Pair, 1).as_unique_index(), 3);
-    assert_eq!(NodePtr::new(ObjectType::Pair, 2).as_unique_index(), 6);
-    assert_eq!(NodePtr::new(ObjectType::Pair, 3).as_unique_index(), 9);
-    assert_eq!(NodePtr::new(ObjectType::Bytes, 0).as_unique_index(), 1);
-    assert_eq!(NodePtr::new(ObjectType::Bytes, 1).as_unique_index(), 4);
-    assert_eq!(NodePtr::new(ObjectType::Bytes, 2).as_unique_index(), 7);
-    assert_eq!(NodePtr::new(ObjectType::Bytes, 3).as_unique_index(), 10);
-    assert_eq!(NodePtr::new(ObjectType::Bytes, 4).as_unique_index(), 13);
 }
 
 #[test]

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -167,21 +167,28 @@ impl Default for Allocator {
     }
 }
 
-pub fn canonical_positive_integer(v: &[u8]) -> bool {
-    if v.is_empty() {
-        // empty buffer is 0/nil
-        true
-    } else if (v.len() == 1 && v[0] == 0)
+pub fn fits_in_small_atom(v: &[u8]) -> Option<u32> {
+    if !v.is_empty()
+        && (v.len() > 4
+        || (v.len() == 1 && v[0] == 0)
         // a 1-byte buffer of 0 is not the canonical representation of 0
         || (v[0] & 0x80) != 0
         // if the top bit is set, it's a negative number (i.e. not positive)
         || (v[0] == 0 && (v[1] & 0x80) == 0)
+        // if the buffer is 4 bytes, the top byte can't use more than 2 bits.
+        // otherwise the integer won't fit in 26 bits
+        || (v.len() == 4 && v[0] > 0x03))
     {
-        // if the top byte is a 0 but the top bit of the next byte is not set, that's a redundant
-        // leading zero. i.e. not canonical representation
-        false
+        // if the top byte is a 0 but the top bit of the next byte is not set,
+        // that's a redundant leading zero. i.e. not canonical representation
+        None
     } else {
-        true
+        let mut ret: u32 = 0;
+        for b in v {
+            ret <<= 8;
+            ret |= *b as u32;
+        }
+        Some(ret)
     }
 }
 
@@ -259,12 +266,7 @@ impl Allocator {
         }
         let idx = self.atom_vec.len();
         self.check_atom_limit()?;
-        if v.len() <= 3 && canonical_positive_integer(v) {
-            let mut ret: u32 = 0;
-            for b in v {
-                ret <<= 8;
-                ret |= *b as u32;
-            }
+        if let Some(ret) = fits_in_small_atom(v) {
             self.small_atoms += 1;
             Ok(NodePtr::new(ObjectType::SmallAtom, ret as usize))
         } else {
@@ -345,7 +347,10 @@ impl Allocator {
                 let buf: [u8; 4] = val.to_be_bytes();
                 let buf = &buf[4 - len as usize..];
                 let substr = &buf[start as usize..end as usize];
-                if !canonical_positive_integer(substr) {
+                if let Some(new_val) = fits_in_small_atom(substr) {
+                    self.small_atoms += 1;
+                    Ok(NodePtr::new(ObjectType::SmallAtom, new_val as usize))
+                } else {
                     let start = self.u8_vec.len();
                     let end = start + substr.len();
                     self.u8_vec.extend_from_slice(substr);
@@ -355,14 +360,6 @@ impl Allocator {
                         end: end as u32,
                     });
                     Ok(NodePtr::new(ObjectType::Bytes, idx))
-                } else {
-                    let mut new_val: u32 = 0;
-                    for i in substr {
-                        new_val <<= 8;
-                        new_val |= *i as u32;
-                    }
-                    self.small_atoms += 1;
-                    Ok(NodePtr::new(ObjectType::SmallAtom, new_val as usize))
                 }
             }
         }
@@ -509,16 +506,7 @@ impl Allocator {
             ObjectType::Bytes => {
                 let atom = self.atom_vec[node.index() as usize];
                 let buf = &self.u8_vec[atom.start as usize..atom.end as usize];
-                if buf.len() > 3 || !canonical_positive_integer(buf) {
-                    None
-                } else {
-                    let mut ret: u32 = 0;
-                    for v in buf {
-                        ret <<= 8;
-                        ret |= *v as u32;
-                    }
-                    Some(ret)
-                }
+                fits_in_small_atom(buf)
             }
             _ => None,
         }
@@ -1808,14 +1796,16 @@ fn test_auto_small_number(#[case] value: Number, #[case] expect_small: bool) {
 #[case(&[0xff], false)]
 #[case(&[0xff, 0xff], false)]
 #[case(&[0x80, 0xff, 0xff], false)]
-// we use a simple heuristic, for atoms. if we have more than 3 bytes, we assume
-// it's not small. Even though it would have fit in 26 bits
-#[case(&[0x1, 0xff, 0xff, 0xff], false)]
 // small positive intergers can be small
 #[case(&[0x01], true)]
 #[case(&[0x00, 0xff], true)]
 #[case(&[0x7f, 0xff], true)]
 #[case(&[0x7f, 0xff, 0xff], true)]
+#[case(&[0x00, 0xff, 0xff, 0xff], true)]
+#[case(&[0x02, 0x00, 0x00, 0x00], true)]
+#[case(&[0x03, 0xff, 0xff, 0xff], true)]
+// too big
+#[case(&[0x04, 0x00, 0x00, 0x00], false)]
 fn test_auto_small_number_from_buf(#[case] buf: &[u8], #[case] expect_small: bool) {
     let mut a = Allocator::new();
     let atom = a.new_atom(buf).expect("new_atom()");
@@ -1825,4 +1815,36 @@ fn test_auto_small_number_from_buf(#[case] buf: &[u8], #[case] expect_small: boo
         assert_eq!(v, a.number(atom).to_u32().expect("to_u32()"));
     }
     assert_eq!(buf, a.atom(atom).as_ref());
+}
+
+#[cfg(test)]
+#[rstest]
+// redundant leading zeros are not canoncial
+#[case(&[0x00], None)]
+#[case(&[0x00, 0x7f], None)]
+// negative numbers cannot be small ints
+#[case(&[0x80], None)]
+#[case(&[0xff], None)]
+// redundant leading 0xff are still negative
+#[case(&[0xff, 0xff], None)]
+#[case(&[0x80, 0xff, 0xff], None)]
+// to big
+#[case(&[0x04, 0x00, 0x00, 0x00], None)]
+#[case(&[0x05, 0x00, 0x00, 0x00], None)]
+#[case(&[0x04, 0x00, 0x00, 0x00, 0x00], None)]
+// small positive intergers can be small
+#[case(&[0x01], Some(0x01))]
+#[case(&[0x00, 0x80], Some(0x80))]
+#[case(&[0x00, 0xff], Some(0xff))]
+#[case(&[0x7f, 0xff], Some(0x7fff))]
+#[case(&[0x00, 0x80, 0x00], Some(0x8000))]
+#[case(&[0x00, 0xff, 0xff], Some(0xffff))]
+#[case(&[0x7f, 0xff, 0xff], Some(0x7fffff))]
+#[case(&[0x00, 0x80, 0x00, 0x00], Some(0x800000))]
+#[case(&[0x00, 0xff, 0xff, 0xff], Some(0xffffff))]
+#[case(&[0x02, 0x00, 0x00, 0x00], Some(0x2000000))]
+#[case(&[0x03, 0x00, 0x00, 0x00], Some(0x3000000))]
+#[case(&[0x03, 0xff, 0xff, 0xff], Some(0x3ffffff))]
+fn test_fits_in_small_atom(#[case] buf: &[u8], #[case] expected: Option<u32>) {
+    assert_eq!(fits_in_small_atom(buf), expected);
 }

--- a/src/serde/object_cache.rs
+++ b/src/serde/object_cache.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 /// `ObjectCache` provides a way to calculate and cache values for each node
 /// in a clvm object tree. It can be used to calculate the sha256 tree hash
 /// for an object and save the hash for all the child objects for building
@@ -13,7 +14,7 @@ type CachedFunction<T> = fn(&mut ObjectCache<T>, &Allocator, NodePtr) -> Option<
 use super::bytes32::{hash_blobs, Bytes32};
 
 pub struct ObjectCache<'a, T> {
-    cache: Vec<Option<T>>,
+    cache: HashMap<NodePtr, T>,
     allocator: &'a Allocator,
 
     /// The function `f` is expected to calculate its T value recursively based
@@ -28,9 +29,8 @@ pub struct ObjectCache<'a, T> {
 
 impl<'a, T: Clone> ObjectCache<'a, T> {
     pub fn new(allocator: &'a Allocator, f: CachedFunction<T>) -> Self {
-        let cache = vec![];
         Self {
-            cache,
+            cache: HashMap::new(),
             allocator,
             f,
         }
@@ -45,21 +45,12 @@ impl<'a, T: Clone> ObjectCache<'a, T> {
 
     /// return the cached value for this node, or `None`
     fn get_from_cache(&self, node: &NodePtr) -> Option<&T> {
-        let index = node.as_unique_index();
-        if index < self.cache.len() {
-            self.cache[index].as_ref()
-        } else {
-            None
-        }
+        self.cache.get(node)
     }
 
     /// set the cached value for a node
     fn set(&mut self, node: &NodePtr, v: T) {
-        let index = node.as_unique_index();
-        if index >= self.cache.len() {
-            self.cache.resize(index + 1, None);
-        }
-        self.cache[index] = Some(v)
+        self.cache.insert(*node, v);
     }
 
     /// calculate the function's value for the given node, traversing uncached children

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -9,9 +9,6 @@ homepage = "https://github.com/Chia-Network/clvm_rs/tools/"
 repository = "https://github.com/Chia-Network/clvm_rs/tools/"
 readme = "README.md"
 
-[profile.release]
-lto = true
-
 [dependencies]
 hex-literal = "=0.4.1"
 hex = "=0.4.3"


### PR DESCRIPTION
This factors out some common code and generally simplifies and unifies the behavior. With additional tests and fuzzer checks.

The second commit addresses the use of `as_unique_address()`, which is used in `ObjectCache` as a cheap hash map (index into a `Vec`). However, with the `SmallAtom` feature, `NodePtr` indices is no longer dense, and it no longer works to use a `Vec` instead of a `HashMap`. It allocates too much memory if you create an atom with value `0x3ffffff`.

This commit is included in this PR since the increased fidelity of matching atoms to `SmallAtom` pushed the fuzzer over the limit and started failing with out-of-memory.