### PR TITLE
precalculate SHA256 hashes. Speed-up: 1.2x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,7 @@ dependencies = [
  "chia-bls 0.4.0",
  "criterion",
  "hex",
+ "hex-literal",
  "k256",
  "lazy_static",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ num-integer = "0.1.45"
 chia-bls = "0.4.0"
 sha2 = "0.10.8"
 openssl = { version = "=0.10.55", features = ["vendored"], optional = true }
+hex-literal = "=0.4.1"
 # for secp sigs
 k256 = { version = "0.13.1", features = ["ecdsa"] }
 p256 = { version = "0.13.2", features = ["ecdsa"] }

--- a/src/op_utils.rs
+++ b/src/op_utils.rs
@@ -16,6 +16,18 @@ pub fn get_args<const N: usize>(
     args: NodePtr,
     name: &str,
 ) -> Result<[NodePtr; N], EvalErr> {
+    match_args::<N>(a, args).ok_or_else(|| {
+        EvalErr(
+            args,
+            format!(
+                "{name} takes exactly {N} argument{}",
+                if N == 1 { "" } else { "s" }
+            ),
+        )
+    })
+}
+
+pub fn match_args<const N: usize>(a: &Allocator, args: NodePtr) -> Option<[NodePtr; N]> {
     let mut next = args;
     let mut counter = 0;
     let mut ret = [NodePtr::NIL; N];
@@ -23,28 +35,16 @@ pub fn get_args<const N: usize>(
     while let Some((first, rest)) = a.next(next) {
         next = rest;
         if counter == N {
-            return err(
-                args,
-                &format!(
-                    "{name} takes exactly {N} argument{}",
-                    if N == 1 { "" } else { "s" }
-                ),
-            );
+            return None;
         }
         ret[counter] = first;
         counter += 1;
     }
 
     if counter != N {
-        err(
-            args,
-            &format!(
-                "{name} takes exactly {N} argument{}",
-                if N == 1 { "" } else { "s" }
-            ),
-        )
+        None
     } else {
-        Ok(ret)
+        Some(ret)
     }
 }
 


### PR DESCRIPTION
This was @Quexington 's suggestion.

An earlier version of this description had benchmarks numbers that were invalid. It has been updated with correct benchmarks.

# change

For `op_sha256()`, use pre-calculated SHA-256 hashes for common cases. Specifically `(sha256 1 <op-code>)` which is a common case when computing the tree hash of programs, e.g. puzzles.

This gives a modest speed-up on most blocks.

# benchmarks

These are benchmarks in `chia_rs`, as those are higher level and running real block generators.

All benchmarks:
```
group                                                    after                 before
-----                                                    -----                 ------
run_block_generator block-1ee588dc                       1.00     76.9±0.38ms  1.20     91.9±0.61ms
run_block_generator block-1ee588dc-compressed            1.00     76.2±0.57ms  1.21     92.3±0.81ms
run_block_generator block-225758                         1.00      3.5±0.02ms  1.09      3.8±0.02ms
run_block_generator block-225758-compressed              1.00      3.5±0.01ms  1.08      3.8±0.01ms
run_block_generator block-4671894                        1.00    199.6±3.00ms  1.07    214.2±0.83ms
run_block_generator block-4671894-compressed             1.00    199.6±1.13ms  1.07    214.3±2.26ms
run_block_generator block-6fe59b24                       1.00     85.1±0.72ms  1.20    102.5±0.17ms
run_block_generator block-6fe59b24-compressed            1.00     83.7±0.51ms  1.20    100.4±1.41ms
run_block_generator block-834752                         1.00      6.4±0.05ms  1.19      7.7±0.06ms
run_block_generator block-834752-compressed              1.00      6.4±0.05ms  1.17      7.5±0.09ms
run_block_generator block-b45268ac                       1.00     75.9±0.46ms  1.19     90.6±0.43ms
run_block_generator block-b45268ac-compressed            1.00     74.5±0.36ms  1.20     89.3±0.76ms
run_block_generator block-c2a8df0d                       1.00     90.6±0.56ms  1.18    106.8±0.35ms
run_block_generator block-c2a8df0d-compressed            1.00     87.4±0.21ms  1.21    105.9±0.30ms
run_block_generator block-e5002df2                       1.00     80.2±0.36ms  1.19     95.7±0.52ms
run_block_generator block-e5002df2-compressed            1.00     78.4±0.23ms  1.21     94.8±0.77ms
run_block_generator deep-recursion-plus                  1.00   1113.4±7.02ms  1.00   1111.0±0.87ms
run_block_generator deep-recursion-plus-compressed       1.00   1109.7±3.14ms  1.00   1112.3±2.23ms
run_block_generator duplicate-coin-announce              1.00  1296.6±20.51ms  1.00   1299.8±4.42ms
run_block_generator duplicate-coin-announce-compressed   1.00  1299.1±21.38ms  1.00   1299.1±4.27ms
run_block_generator recursion-pairs                      1.00    896.2±7.74ms  1.01    901.4±2.30ms
run_block_generator recursion-pairs-compressed           1.00    894.0±2.69ms  1.01    902.2±2.17ms
run_block_generator2 block-1ee588dc                      1.00     41.4±0.36ms  1.21     49.9±0.19ms
run_block_generator2 block-1ee588dc-compressed           1.00     12.2±0.10ms  1.15     14.0±1.12ms
run_block_generator2 block-225758                        1.00      2.8±0.02ms  1.07      3.0±0.02ms
run_block_generator2 block-225758-compressed             1.00      2.8±0.01ms  1.07      3.0±0.01ms
run_block_generator2 block-4671894                       1.00    159.0±0.69ms  1.06    168.9±0.67ms
run_block_generator2 block-4671894-compressed            1.00    160.0±1.07ms  1.06    169.0±0.43ms
run_block_generator2 block-6fe59b24                      1.00     46.5±0.43ms  1.21     56.2±0.32ms
run_block_generator2 block-6fe59b24-compressed           1.00     15.4±0.20ms  1.12     17.2±0.14ms
run_block_generator2 block-834752                        1.00      3.9±0.04ms  1.20      4.7±0.02ms
run_block_generator2 block-834752-compressed             1.00      2.0±0.03ms  1.16      2.4±0.01ms
run_block_generator2 block-b45268ac                      1.00     41.0±0.40ms  1.20     49.3±0.30ms
run_block_generator2 block-b45268ac-compressed           1.00     12.2±0.04ms  1.10     13.5±0.07ms
run_block_generator2 block-c2a8df0d                      1.00     47.4±0.06ms  1.23     58.3±0.44ms
run_block_generator2 block-c2a8df0d-compressed           1.00     11.8±0.02ms  1.10     13.0±0.12ms
run_block_generator2 block-e5002df2                      1.00     42.9±0.37ms  1.23     52.6±0.10ms
run_block_generator2 block-e5002df2-compressed           1.00     13.9±0.06ms  1.13     15.8±0.15ms
run_block_generator2 deep-recursion-plus                 1.00   1106.8±2.95ms  1.00   1111.6±1.62ms
run_block_generator2 deep-recursion-plus-compressed      1.00   1110.0±3.25ms  1.00   1111.5±1.26ms
run_block_generator2 duplicate-coin-announce             1.00  1300.9±17.45ms  1.00   1299.7±3.79ms
run_block_generator2 duplicate-coin-announce-compressed  1.00   1285.2±3.11ms  1.01   1299.1±4.59ms
run_block_generator2 recursion-pairs                     1.00    892.8±1.78ms  1.01    900.2±2.82ms
run_block_generator2 recursion-pairs-compressed          1.00    893.4±1.10ms  1.01    900.6±0.87ms
```