### PR TITLE
Bump CI python version

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: [3.8]
+        python: [3.9]
 
     steps:
     - uses: actions/checkout@v3
@@ -184,7 +184,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python: [3.8]
+        python: [3.9]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -219,7 +219,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: [3.8]
+        python: [3.9]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: [3.7]
+        python: [3.8]
 
     steps:
     - uses: actions/checkout@v3
@@ -184,7 +184,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        python: [3.7]
+        python: [3.8]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -219,7 +219,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: [3.7]
+        python: [3.8]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Python 3.7 was out of date.
(Python 3.8 will be end of life October this year)