### PR TITLE
add parameterized test for the softfork guard and its behavior

### DIFF
--- a/src/test_ops.rs
+++ b/src/test_ops.rs
@@ -99,6 +99,8 @@ fn parse_atom(a: &mut Allocator, v: &str) -> NodePtr {
             "g2_map" => a.new_atom(&[57]).unwrap(),
             "bls_pairing_identity" => a.new_atom(&[58]).unwrap(),
             "bls_verify" => a.new_atom(&[59]).unwrap(),
+            "modpow" => a.new_atom(&[60]).unwrap(),
+            "%" => a.new_atom(&[61]).unwrap(),
             "secp256k1_verify" => a.new_atom(&[0x13, 0xd6, 0x1f, 0x00]).unwrap(),
             "secp256r1_verify" => a.new_atom(&[0x1c, 0x3a, 0x8f, 0x00]).unwrap(),
             _ => {


### PR DESCRIPTION
this adds a new test for the softfork guard, parameterized on mempool mode, the extension value passed in and flags.
Since the BLS soft-fork has already activated, the `flags` parameter isn't so interesting. but it will be for the CHIP-34 patch.