### PR TITLE
update serde

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
-            toolchain: nightly-2024-02-11
+            toolchain: nightly
             components: rustfmt, clippy
       - name: fmt
         run: |


### PR DESCRIPTION
This fixes a build error in the fuzzers.

```
error[E0658]: `#[diagnostic]` attribute name space is experimental
   --> /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.204/src/de/mod.rs:537:5
    |
537 |     diagnostic::on_unimplemented(
    |     ^^^^^^^^^^
    |
    = note: see issue #111996 <https://github.com/rust-lang/rust/issues/111996> for more information
    = help: add `#![feature(diagnostic_namespace)]` to the crate attributes to enable
    = note: this compiler was built on 2024-02-10; consider upgrading it if it is out of date
```