### PR TITLE
Clippy fixes

### DIFF
--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -495,7 +495,7 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
                 Operation::PostEval => {
                     let f = self.posteval_stack.pop().unwrap();
                     let peek: Option<NodePtr> = self.val_stack.last().copied();
-                    f(&mut self.allocator, peek);
+                    f(self.allocator, peek);
                     0
                 }
             };

--- a/wasm/src/run_program.rs
+++ b/wasm/src/run_program.rs
@@ -11,12 +11,6 @@ use clvmr::cost::Cost;
 use clvmr::run_program::run_program;
 use clvmr::serde::{node_from_bytes, node_from_bytes_backrefs, node_to_bytes};
 
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 #[wasm_bindgen]
 pub struct Flag;
 


### PR DESCRIPTION
Fixes clippy warnings. `wee_alloc` isn't a dependency and is 3 years old, and should not be used.