### PR TITLE
ENABLE_FIXED_DIV is always enabled

### DIFF
--- a/op-tests/test-more-ops.txt
+++ b/op-tests/test-more-ops.txt
@@ -512,27 +512,27 @@ all ( 1 ) 2 ( ) => 0 | 1100
 
 ; division round towards negative infinity
 / 10 3 => 3 | 1006
-/ -10 3 => FAIL
-/ -10 -3 => FAIL
-/ 10 -3 => FAIL
+/ -10 3 => -4 | 1006
+/ -10 -3 => 3 | 1006
+/ 10 -3 => -4 | 1006
 
 / 80001 73 => 1095 | 1024
-/ -80001 73 => FAIL
+/ -80001 73 => -1096 | 1024
 / 0x00000000000000000a 0x000000000000000005 => 2 | 1070
 
 / 1 10 => 0 | 996
-/ -1 -10 => FAIL
+/ -1 -10 => 0 | 996
 
 / 1 1 => 1 | 1006
-/ 1 -1 =>  FAIL
-/ -1 -1 => FAIL
-/ -1 1 => FAIL
-/ 0 -1 => FAIL
+/ 1 -1 => -1 | 1006
+/ -1 -1 => 1 | 1006
+/ -1 1 => -1 | 1006
+/ 0 -1 => 0 | 992
 / 0 1 => 0 | 992
 
-; division with negative numbers are not allowed
-/ -1 10 => FAIL
-/ 1 -10 => FAIL
+; division with negative numbers are allowed now
+/ -1 10 => -1 | 1006
+/ 1 -10 => -1 | 1006
 
 ; wrong number of arguments
 divmod => FAIL

--- a/src/chia_dialect.rs
+++ b/src/chia_dialect.rs
@@ -9,10 +9,9 @@ use crate::cost::Cost;
 use crate::dialect::{Dialect, OperatorSet};
 use crate::err_utils::err;
 use crate::more_ops::{
-    op_add, op_all, op_any, op_ash, op_coinid, op_concat, op_div, op_div_fixed, op_divmod, op_gr,
-    op_gr_bytes, op_logand, op_logior, op_lognot, op_logxor, op_lsh, op_mod, op_modpow,
-    op_multiply, op_not, op_point_add, op_pubkey_for_exp, op_sha256, op_strlen, op_substr,
-    op_subtract, op_unknown,
+    op_add, op_all, op_any, op_ash, op_coinid, op_concat, op_div, op_divmod, op_gr, op_gr_bytes,
+    op_logand, op_logior, op_lognot, op_logxor, op_lsh, op_mod, op_modpow, op_multiply, op_not,
+    op_point_add, op_pubkey_for_exp, op_sha256, op_strlen, op_substr, op_subtract, op_unknown,
 };
 use crate::reduction::Response;
 use crate::secp_ops::{op_secp256k1_verify, op_secp256r1_verify};
@@ -28,10 +27,6 @@ pub const LIMIT_HEAP: u32 = 0x0004;
 // enables the BLS ops extensions *outside* the softfork guard. This is a
 // hard-fork and should only be enabled when it activates
 pub const ENABLE_BLS_OPS_OUTSIDE_GUARD: u32 = 0x0020;
-
-// enabling this is a hard fork. This will allow negative numbers in the
-// division operator
-pub const ENABLE_FIXED_DIV: u32 = 0x0080;
 
 // The default mode when running grnerators in mempool-mode (i.e. the stricter
 // mode)
@@ -128,13 +123,7 @@ impl Dialect for ChiaDialect {
             16 => op_add,
             17 => op_subtract,
             18 => op_multiply,
-            19 => {
-                if (flags & ENABLE_FIXED_DIV) != 0 {
-                    op_div_fixed
-                } else {
-                    op_div
-                }
-            }
+            19 => op_div,
             20 => op_divmod,
             21 => op_gr,
             22 => op_ash,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,7 @@ pub use allocator::{Allocator, Atom, NodePtr, SExp};
 pub use chia_dialect::ChiaDialect;
 pub use run_program::run_program;
 
-pub use chia_dialect::{
-    ENABLE_BLS_OPS_OUTSIDE_GUARD, ENABLE_FIXED_DIV, LIMIT_HEAP, MEMPOOL_MODE, NO_UNKNOWN_OPS,
-};
+pub use chia_dialect::{ENABLE_BLS_OPS_OUTSIDE_GUARD, LIMIT_HEAP, MEMPOOL_MODE, NO_UNKNOWN_OPS};
 
 #[cfg(feature = "counters")]
 pub use run_program::run_program_with_counters;

--- a/src/more_ops.rs
+++ b/src/more_ops.rs
@@ -530,23 +530,6 @@ pub fn op_div(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
     if a1.sign() == Sign::NoSign {
         err(input, "div with 0")
     } else {
-        if a0.sign() == Sign::Minus || a1.sign() == Sign::Minus {
-            return err(input, "div operator with negative operands is deprecated");
-        }
-        let q = a0.div_floor(&a1);
-        let q = a.new_number(q)?;
-        Ok(malloc_cost(a, cost, q))
-    }
-}
-
-pub fn op_div_fixed(a: &mut Allocator, input: NodePtr, _max_cost: Cost) -> Response {
-    let [v0, v1] = get_args::<2>(a, input, "/")?;
-    let (a0, a0_len) = int_atom(a, v0, "/")?;
-    let (a1, a1_len) = int_atom(a, v1, "/")?;
-    let cost = DIV_BASE_COST + ((a0_len + a1_len) as Cost) * DIV_COST_PER_BYTE;
-    if a1.sign() == Sign::NoSign {
-        err(input, "div with 0")
-    } else {
         let q = a0.div_floor(&a1);
         let q = a.new_number(q)?;
         Ok(malloc_cost(a, cost, q))

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -559,7 +559,7 @@ struct RunProgramTest<'a> {
 use crate::test_ops::parse_exp;
 
 #[cfg(test)]
-use crate::chia_dialect::{ENABLE_BLS_OPS_OUTSIDE_GUARD, ENABLE_FIXED_DIV, NO_UNKNOWN_OPS};
+use crate::chia_dialect::{ENABLE_BLS_OPS_OUTSIDE_GUARD, NO_UNKNOWN_OPS};
 
 #[cfg(test)]
 const TEST_CASES: &[RunProgramTest] = &[
@@ -567,22 +567,6 @@ const TEST_CASES: &[RunProgramTest] = &[
         prg: "(/ (q . 10) (q . -3))",
         args: "()",
         flags: 0,
-        result: None,
-        cost: 0,
-        err: "div operator with negative operands is deprecated",
-    },
-    RunProgramTest {
-        prg: "(/ (q . -10) (q . 3))",
-        args: "()",
-        flags: 0,
-        result: None,
-        cost: 0,
-        err: "div operator with negative operands is deprecated",
-    },
-    RunProgramTest {
-        prg: "(/ (q . 10) (q . -3))",
-        args: "()",
-        flags: ENABLE_FIXED_DIV,
         result: Some("-4"),
         cost: 1047,
         err: "",
@@ -590,7 +574,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(/ (q . -10) (q . 3))",
         args: "()",
-        flags: ENABLE_FIXED_DIV,
+        flags: 0,
         result: Some("-4"),
         cost: 1047,
         err: "",
@@ -598,7 +582,7 @@ const TEST_CASES: &[RunProgramTest] = &[
     RunProgramTest {
         prg: "(/ (q . -1) (q . 2))",
         args: "()",
-        flags: ENABLE_FIXED_DIV,
+        flags: 0,
         result: Some("-1"),
         cost: 1047,
         err: "",

--- a/wasm/tests/index.js
+++ b/wasm/tests/index.js
@@ -114,9 +114,9 @@ test_case("Test negative div", function () {
   const arg = bytesFromHex("80");
   // 100,000,000,000
   const max_cost = BigInt("100000000000");
-  expect_throw(function () {
-    wasm.run_chia_program(prog, arg, max_cost, 0);
-  });
+  const [cost, sexp] = wasm.run_chia_program(prog, arg, max_cost, 0);
+  // div rounds towards negative infinity, so this is -2
+  expect_equal(sexp.atom.toString(), "254");
 });
 
 test_case("Test serialized_length", function () {


### PR DESCRIPTION
 now since the hard fork activated. Enable it unconditionally and remove the flag.