### PR TITLE
remove `ENABLE_BLS_OPS_OUTSIDE_GUARD`

### DIFF
--- a/fuzz/fuzz_targets/run_program.rs
+++ b/fuzz/fuzz_targets/run_program.rs
@@ -2,9 +2,7 @@
 use libfuzzer_sys::fuzz_target;
 
 use clvmr::allocator::Allocator;
-use clvmr::chia_dialect::{
-    ChiaDialect, ENABLE_BLS_OPS_OUTSIDE_GUARD, MEMPOOL_MODE, NO_UNKNOWN_OPS,
-};
+use clvmr::chia_dialect::{ChiaDialect, MEMPOOL_MODE, NO_UNKNOWN_OPS};
 use clvmr::cost::Cost;
 use clvmr::reduction::Reduction;
 use clvmr::run_program::run_program;
@@ -22,12 +20,7 @@ fuzz_target!(|data: &[u8]| {
 
     let allocator_checkpoint = allocator.checkpoint();
 
-    for flags in [
-        0,
-        ENABLE_BLS_OPS_OUTSIDE_GUARD,
-        ENABLE_BLS_OPS_OUTSIDE_GUARD | NO_UNKNOWN_OPS,
-        MEMPOOL_MODE,
-    ] {
+    for flags in [0, NO_UNKNOWN_OPS, MEMPOOL_MODE] {
         let dialect = ChiaDialect::new(flags);
         allocator.restore_checkpoint(&allocator_checkpoint);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub use allocator::{Allocator, Atom, NodePtr, SExp};
 pub use chia_dialect::ChiaDialect;
 pub use run_program::run_program;
 
-pub use chia_dialect::{ENABLE_BLS_OPS_OUTSIDE_GUARD, LIMIT_HEAP, MEMPOOL_MODE, NO_UNKNOWN_OPS};
+pub use chia_dialect::{LIMIT_HEAP, MEMPOOL_MODE, NO_UNKNOWN_OPS};
 
 #[cfg(feature = "counters")]
 pub use run_program::run_program_with_counters;

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -549,7 +549,7 @@ pub fn run_program_with_counters<'a, D: Dialect>(
 mod tests {
     use super::*;
 
-    use crate::chia_dialect::{ENABLE_BLS_OPS_OUTSIDE_GUARD, NO_UNKNOWN_OPS};
+    use crate::chia_dialect::NO_UNKNOWN_OPS;
     use crate::test_ops::parse_exp;
 
     use rstest::rstest;
@@ -1203,7 +1203,7 @@ mod tests {
         RunProgramTest {
             prg: "(coinid (q . 0x1234500000000000000000000000000000000000000000000000000000000000) (q . 0x6789abcdef000000000000000000000000000000000000000000000000000000) (q . 123456789))",
             args: "()",
-            flags: ENABLE_BLS_OPS_OUTSIDE_GUARD,
+            flags: 0,
             result: Some("0x69bfe81b052bfc6bd7f3fb9167fec61793175b897c16a35827f947d5cc98e4bc"),
             cost: 861,
             err: "",
@@ -1211,20 +1211,10 @@ mod tests {
         RunProgramTest {
             prg: "(coinid (q . 0x1234500000000000000000000000000000000000000000000000000000000000) (q . 0x6789abcdef000000000000000000000000000000000000000000000000000000) (q . 0x000123456789))",
             args: "()",
-            flags: ENABLE_BLS_OPS_OUTSIDE_GUARD,
+            flags: 0,
             result: None,
             cost: 861,
             err: "coinid: invalid amount (may not have redundant leading zero)",
-        },
-        // make sure the coinid operator is not available unless the flag is
-        // specified
-        RunProgramTest {
-            prg: "(coinid (q . 0x1234500000000000000000000000000000000000000000000000000000000000) (q . 0x6789abcdef000000000000000000000000000000000000000000000000000000) (q . 0x000123456789))",
-            args: "()",
-            flags: NO_UNKNOWN_OPS,
-            result: None,
-            cost: 861,
-            err: "unimplemented operator",
         },
 
         // secp261k1
@@ -1326,52 +1316,52 @@ mod tests {
     // this program raises an exception if the computed coin ID matches the
     // expected
     #[case::coinid("(i (= (coinid (q . 0x1234500000000000000000000000000000000000000000000000000000000000) (q . 0x6789abcdef000000000000000000000000000000000000000000000000000000) (q . 123456789)) (q . 0x69bfe81b052bfc6bd7f3fb9167fec61793175b897c16a35827f947d5cc98e4bd)) (q . 0) (q x))",
-    (1432, 0, ENABLE_BLS_OPS_OUTSIDE_GUARD),
+    (1432, 0, 0),
     "clvm raise")]
     // also test the opposite. This program is the same as above but it raises
     // if the coin ID is a mismatch
     #[case::coinid("(i (= (coinid (q . 0x1234500000000000000000000000000000000000000000000000000000000000) (q . 0x6789abcdef000000000000000000000000000000000000000000000000000000) (q . 123456789)) (q . 0x69bfe81b052bfc6bd7f3fb9167fec61793175b897c16a35827f947d5cc98e4bc)) (q . 0) (q x))",
-    (1432, 0, ENABLE_BLS_OPS_OUTSIDE_GUARD),
+    (1432, 0, 0),
     "")]
     // modpow
     #[case::modpow(
     "(i (= (modpow (q . 12345) (q . 6789) (q . 44444444444)) (q . 13456191581)) (q . 0) (q x))",
-    (18241, 0, ENABLE_BLS_OPS_OUTSIDE_GUARD),
+    (18241, 0, 0),
     ""
 )]
     #[case::modpow(
     "(i (= (modpow (q . 12345) (q . 6789) (q . 44444444444)) (q . 13456191582)) (q . 0) (q x))",
-    (18241, 0, ENABLE_BLS_OPS_OUTSIDE_GUARD),
+    (18241, 0, 0),
     "clvm raise"
 )]
     // mod
     #[case::modulus(
     "(i (= (% (q . 80001) (q . 73)) (q . 66)) (q . 0) (q x))",
-    (1564, 0, ENABLE_BLS_OPS_OUTSIDE_GUARD),
+    (1564, 0, 0),
     ""
 )]
     #[case::modulus(
     "(i (= (% (q . 80001) (q . 73)) (q . 67)) (q . 0) (q x))",
-    (1564, 0, ENABLE_BLS_OPS_OUTSIDE_GUARD),
+    (1564, 0, 0),
     "clvm raise"
 )]
     // g1_multiply
     #[case::g1_mul("(i (= (g1_multiply  (q . 0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb) (q . 2)) (q . 0xa572cbea904d67468808c8eb50a9450c9721db309128012543902d0ac358a62ae28f75bb8f1c7c42c39a8c5529bf0f4e)) (q . 0) (q x))",
-    (706634, 0, ENABLE_BLS_OPS_OUTSIDE_GUARD),
+    (706634, 0, 0),
     "")]
     #[case::g1_mul(
     "(i (= (g1_multiply  (q . 0x97f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb) (q . 2)) (q . 0xa572cbea904d67468808c8eb50a9450c9721db309128012543902d0ac358a62ae28f75bb8f1c7c42c39a8c5529bf0f4f)) (q . 0) (q x))",
-    (706634, 0, ENABLE_BLS_OPS_OUTSIDE_GUARD),
+    (706634, 0, 0),
     "clvm raise")]
-    #[case::g1_neg("(i (= (g1_negate (q . 0xb7f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb)) (q . 0xb7f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb)) (q . 0) (q x))", (706634, 0, ENABLE_BLS_OPS_OUTSIDE_GUARD), "clvm raise")]
+    #[case::g1_neg("(i (= (g1_negate (q . 0xb7f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb)) (q . 0xb7f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb)) (q . 0) (q x))", (706634, 0, 0), "clvm raise")]
     #[case::g1_neg("(i (= (g1_negate (q . 0xb2f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb)) (q . 0xb7f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb)) (q . 0) (q x))",
-    (706634, 0, ENABLE_BLS_OPS_OUTSIDE_GUARD),
+    (706634, 0, 0),
     "atom is not a valid G1 point")]
     #[case::g2_add("(i (= (g2_add (q . 0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8) (q . 0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8)) (q . 0xaa4edef9c1ed7f729f520e47730a124fd70662a904ba1074728114d1031e1572c6c886f6b57ec72a6178288c47c335771638533957d540a9d2370f17cc7ed5863bc0b995b8825e0ee1ea1e1e4d00dbae81f14b0bf3611b78c952aacab827a053)) (q . 0) (q x))",
-    (3981700, 0, ENABLE_BLS_OPS_OUTSIDE_GUARD),
+    (3981700, 0, 0),
     "")]
     #[case::g2_add("(i (= (g2_add (q . 0x93e12b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8) (q . 0x93e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb8)) (q . 0xaa4edef9c1ed7f729f520e47730a124fd70662a904ba1074728114d1031e1572c6c886f6b57ec72a6178288c47c335771638533957d540a9d2370f17cc7ed5863bc0b995b8825e0ee1ea1e1e4d00dbae81f14b0bf3611b78c952aacab827a053)) (q . 0) (q x))",
-    (3981700, 0, ENABLE_BLS_OPS_OUTSIDE_GUARD),
+    (3981700, 0, 0),
     "atom is not a G2 point")]
     fn test_softfork(
         #[case] prg: &'static str,
@@ -1379,7 +1369,7 @@ mod tests {
         #[case] err: &'static str,
         #[values(0)] flags: u32,
         #[values(false, true)] mempool: bool,
-        #[values(0, 1, 2)] test_ext: u8,
+        #[values(0, 1)] test_ext: u8,
     ) {
         let (cost, enabled, hard_fork_flag) = fields;
         let softfork_prg =
@@ -1459,13 +1449,9 @@ mod tests {
             prg: outside_guard_prg.as_str(),
             args: "()",
             flags,
-            result: None,
+            result: if err.is_empty() { Some("()") } else { None },
             cost: cost - 140,
-            err: if mempool {
-                "unimplemented operator"
-            } else {
-                "clvm raise"
-            },
+            err,
         };
         run_test_case(&t);
 

--- a/tools/src/bin/benchmark-clvm-cost.rs
+++ b/tools/src/bin/benchmark-clvm-cost.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use clvmr::allocator::{Allocator, NodePtr};
-use clvmr::chia_dialect::{ChiaDialect, ENABLE_BLS_OPS_OUTSIDE_GUARD};
+use clvmr::chia_dialect::ChiaDialect;
 use clvmr::run_program::run_program;
 use linreg::linear_regression_of;
 use std::fs::{create_dir_all, File};
@@ -118,7 +118,7 @@ fn substitute(args: Placeholder, s: NodePtr) -> OpArgs {
 fn time_invocation(a: &mut Allocator, op: u32, arg: OpArgs, flags: u32) -> f64 {
     let call = build_call(a, op, arg, 1, None);
     //println!("{:x?}", &Node::new(a, call));
-    let dialect = ChiaDialect::new(ENABLE_BLS_OPS_OUTSIDE_GUARD);
+    let dialect = ChiaDialect::new(0);
     let start = Instant::now();
     let r = run_program(a, &dialect, call, a.nil(), 11000000000);
     if (flags & ALLOW_FAILURE) == 0 {
@@ -169,7 +169,7 @@ fn time_per_byte(a: &mut Allocator, op: &Operator, output: &mut dyn Write) -> f6
 // establish how much time each additional argument contributes
 fn time_per_arg(a: &mut Allocator, op: &Operator, output: &mut dyn Write) -> f64 {
     let mut samples = Vec::<(f64, f64)>::new();
-    let dialect = ChiaDialect::new(ENABLE_BLS_OPS_OUTSIDE_GUARD);
+    let dialect = ChiaDialect::new(0);
 
     let subst = a
         .new_atom(
@@ -212,7 +212,7 @@ fn base_call_time(
     output: &mut dyn Write,
 ) -> f64 {
     let mut samples = Vec::<(f64, f64)>::new();
-    let dialect = ChiaDialect::new(ENABLE_BLS_OPS_OUTSIDE_GUARD);
+    let dialect = ChiaDialect::new(0);
 
     let subst = a
         .new_atom(


### PR DESCRIPTION
now that the hard-fork has activated, we can enable BLS ops outside the softfork guard unconditionally (and simplify the code)