### PR TITLE
Potential fix for softfork guard issue

### DIFF
--- a/src/chia_dialect.rs
+++ b/src/chia_dialect.rs
@@ -72,6 +72,7 @@ impl Dialect for ChiaDialect {
     ) -> Response {
         let flags = self.flags
             | match extension {
+                OperatorSet::Unknown => 0,
                 OperatorSet::Default => 0,
                 OperatorSet::BLS => 0,
                 OperatorSet::Keccak => ENABLE_KECCAK_OPS_OUTSIDE_GUARD,
@@ -186,10 +187,11 @@ impl Dialect for ChiaDialect {
         match ext {
             // The BLS extensions (and coinid) operators were brought into the
             // main operator set as part of the hard fork
-            0 => OperatorSet::BLS,
+            0 => OperatorSet::Default,
             1 if (self.flags & ENABLE_KECCAK) != 0 => OperatorSet::Keccak,
+            1 => OperatorSet::BLS,
             // new extensions go here
-            _ => OperatorSet::Default,
+            _ => OperatorSet::Unknown,
         }
     }
 

--- a/src/chia_dialect.rs
+++ b/src/chia_dialect.rs
@@ -74,7 +74,6 @@ impl Dialect for ChiaDialect {
             | match extension {
                 OperatorSet::Unknown => 0,
                 OperatorSet::Default => 0,
-                OperatorSet::BLS => 0,
                 OperatorSet::Keccak => ENABLE_KECCAK_OPS_OUTSIDE_GUARD,
             };
 
@@ -187,9 +186,8 @@ impl Dialect for ChiaDialect {
         match ext {
             // The BLS extensions (and coinid) operators were brought into the
             // main operator set as part of the hard fork
-            0 => OperatorSet::Default,
-            1 if (self.flags & ENABLE_KECCAK) != 0 => OperatorSet::Keccak,
-            1 => OperatorSet::BLS,
+            0 | 1 => OperatorSet::Default,
+            2 if (self.flags & ENABLE_KECCAK) != 0 => OperatorSet::Keccak,
             // new extensions go here
             _ => OperatorSet::Unknown,
         }

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -6,7 +6,6 @@ use crate::reduction::Response;
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub enum OperatorSet {
     Default,
-    BLS,
     Keccak, // keccak256 operator
     Unknown,
 }

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -8,6 +8,7 @@ pub enum OperatorSet {
     Default,
     BLS,
     Keccak, // keccak256 operator
+    Unknown,
 }
 
 pub trait Dialect {

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -336,7 +336,7 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
         let extension =
             self.dialect
                 .softfork_extension(uint_atom::<4>(self.allocator, extension, "softfork")? as u32);
-        if extension == OperatorSet::Default {
+        if extension == OperatorSet::Unknown {
             err(args, "unknown softfork extension")
         } else {
             Ok((extension, program, env))


### PR DESCRIPTION
Moves keccak256 into softfork extension 2, to prevent conflicts with the old extension 1. It should be treated as a no-op until the fork activates, and the old extension should continue to work in mempool mode. This is a bug fix that allows that.