### PR TITLE
ObjectCache doesn't need the Allocator as member

### DIFF
--- a/src/serde/de_br.rs
+++ b/src/serde/de_br.rs
@@ -126,8 +126,8 @@ mod tests {
         let buf = Vec::from_hex(serialization_as_hex).unwrap();
         let mut allocator = Allocator::new();
         let node = node_from_bytes_backrefs(&mut allocator, &buf).unwrap();
-        let mut oc = ObjectCache::new(&allocator, treehash);
-        let calculated_hash = oc.get_or_calculate(&node).unwrap();
+        let mut oc = ObjectCache::new(treehash);
+        let calculated_hash = oc.get_or_calculate(&allocator, &node).unwrap();
         let ch: &[u8] = calculated_hash;
         let expected_hash: Vec<u8> = Vec::from_hex(expected_hash_as_hex).unwrap();
         assert_eq!(expected_hash, ch);

--- a/src/serde/ser_br.rs
+++ b/src/serde/ser_br.rs
@@ -28,18 +28,18 @@ pub fn node_to_stream_backrefs<W: io::Write>(
 
     let mut read_cache_lookup = ReadCacheLookup::new();
 
-    let mut thc = ObjectCache::new(allocator, treehash);
-    let mut slc = ObjectCache::new(allocator, serialized_length);
+    let mut thc = ObjectCache::new(treehash);
+    let mut slc = ObjectCache::new(serialized_length);
 
     while let Some(node_to_write) = write_stack.pop() {
         let op = read_op_stack.pop();
         assert!(op == Some(ReadOp::Parse));
 
         let node_serialized_length = *slc
-            .get_or_calculate(&node_to_write)
+            .get_or_calculate(allocator, &node_to_write)
             .expect("couldn't calculate serialized length");
         let node_tree_hash = thc
-            .get_or_calculate(&node_to_write)
+            .get_or_calculate(allocator, &node_to_write)
             .expect("can't get treehash");
         match read_cache_lookup.find_path(node_tree_hash, node_serialized_length) {
             Some(path) => {


### PR DESCRIPTION
Passing it in on-demand is more flexible from a borrow-checker point of view.

I'm interested in using the `ObjectCache` in a scenario where I also keep building new structures in the `Allocator`. Currently, the `ObjectCache` holding a reference to it, won't allow anyone else to make any changes to the allocations.