### PR TITLE
fix Serializer to correctly restore()

### DIFF
--- a/benches/serialize.rs
+++ b/benches/serialize.rs
@@ -35,8 +35,8 @@ fn serialize_benchmark(c: &mut Criterion) {
         group.bench_function(format!("Serializer {name}"), |b| {
             b.iter(|| {
                 let start = Instant::now();
-                let mut ser = Serializer::default();
-                let _ = ser.add(&a, node, None);
+                let mut ser = Serializer::new(None);
+                let _ = ser.add(&a, node);
                 black_box(ser.into_inner());
                 start.elapsed()
             })

--- a/fuzz/fuzz_targets/incremental_serializer.rs
+++ b/fuzz/fuzz_targets/incremental_serializer.rs
@@ -94,10 +94,10 @@ fn do_fuzz(data: &[u8], short_atoms: bool) {
     {
         node_idx += 1;
 
-        let mut ser = Serializer::new();
-        let (done, _) = ser.add(&allocator, first_step, Some(sentinel)).unwrap();
+        let mut ser = Serializer::new(Some(sentinel));
+        let (done, _) = ser.add(&allocator, first_step).unwrap();
         assert!(!done);
-        let (done, _) = ser.add(&allocator, second_step, None).unwrap();
+        let (done, _) = ser.add(&allocator, second_step).unwrap();
         assert!(done);
 
         // now, make sure that we deserialize to the exact same structure, by

--- a/fuzz/fuzz_targets/serializer.rs
+++ b/fuzz/fuzz_targets/serializer.rs
@@ -19,8 +19,8 @@ fn do_fuzz(data: &[u8], short_atoms: bool) {
 
     let b1 = node_to_bytes_backrefs(&allocator, program).unwrap();
 
-    let mut ser = Serializer::new();
-    let (done, _) = ser.add(&allocator, program, None).unwrap();
+    let mut ser = Serializer::new(None);
+    let (done, _) = ser.add(&allocator, program).unwrap();
     assert!(done);
     let b2 = ser.into_inner();
 

--- a/src/serde/identity_hash.rs
+++ b/src/serde/identity_hash.rs
@@ -25,6 +25,7 @@ impl Hasher for IdentityHash {
     }
 }
 
+#[derive(Clone)]
 pub struct RandomState(u64);
 
 impl Default for RandomState {

--- a/src/serde/read_cache_lookup.rs
+++ b/src/serde/read_cache_lookup.rs
@@ -22,7 +22,7 @@ use std::collections::{HashMap, HashSet};
 
 use super::bytes32::{hash_blob, hash_blobs, Bytes32};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ReadCacheLookup {
     root_hash: Bytes32,
 

--- a/src/serde/test.rs
+++ b/src/serde/test.rs
@@ -40,8 +40,8 @@ fn check_round_trip(obj_ser_br_hex: &str) {
     let mut allocator = Allocator::new();
     let obj = node_from_bytes(&mut allocator, &obj_ser_no_br_1).unwrap();
 
-    let mut serializer = Serializer::new();
-    let (done, _) = serializer.add(&allocator, obj, None).unwrap();
+    let mut serializer = Serializer::new(None);
+    let (done, _) = serializer.add(&allocator, obj).unwrap();
     assert!(done);
     let obj_ser_br_2 = serializer.into_inner();
 


### PR DESCRIPTION
to allow resumption of serialization.

It turns out my original patch wasn't tested quite well enough. This adds a test for the important case of restoring the `Serializer` to an earlier state and still be valid to support serialize more CLVM structures.

A somewhat unrelated change is to pass in the sentinel node to the `Serializer` constructor, rather than at every call to `add()`.