### PR TITLE
address incremental-serializer fuzzer failures

### DIFF
--- a/fuzz/fuzz_targets/deserialize_br_rand_tree.rs
+++ b/fuzz/fuzz_targets/deserialize_br_rand_tree.rs
@@ -11,7 +11,7 @@ fuzz_target!(|data: &[u8]| {
     let mut allocator = Allocator::new();
     let mut unstructured = arbitrary::Unstructured::new(data);
 
-    let program = make_tree::make_tree(&mut allocator, &mut unstructured);
+    let (program, _) = make_tree::make_tree(&mut allocator, &mut unstructured);
 
     let b1 = node_to_bytes_backrefs(&allocator, program).unwrap();
 

--- a/fuzz/fuzz_targets/node_eq.rs
+++ b/fuzz/fuzz_targets/node_eq.rs
@@ -1,12 +1,17 @@
 use clvmr::{Allocator, NodePtr, SExp};
+use std::collections::HashSet;
 
 /// compare two CLVM trees. Returns true if they are identical, false otherwise
 pub fn node_eq(allocator: &Allocator, lhs: NodePtr, rhs: NodePtr) -> bool {
     let mut stack = vec![(lhs, rhs)];
+    let mut visited = HashSet::<NodePtr>::new();
 
     while let Some((l, r)) = stack.pop() {
         match (allocator.sexp(l), allocator.sexp(r)) {
             (SExp::Pair(ll, lr), SExp::Pair(rl, rr)) => {
+                if !visited.insert(l) {
+                    continue;
+                }
                 stack.push((lr, rr));
                 stack.push((ll, rl));
             }

--- a/fuzz/fuzz_targets/object_cache.rs
+++ b/fuzz/fuzz_targets/object_cache.rs
@@ -4,38 +4,51 @@ mod make_tree;
 
 use clvmr::serde::{node_to_bytes, serialized_length, treehash, ObjectCache};
 use clvmr::{Allocator, NodePtr, SExp};
+use fuzzing_utils::tree_hash;
 use libfuzzer_sys::fuzz_target;
-
-use fuzzing_utils::{tree_hash, visit_tree};
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::collections::HashSet;
 
 enum Op {
-    Cons,
+    Cons(NodePtr),
     Traverse(NodePtr),
 }
 
 fn compute_serialized_len(a: &Allocator, n: NodePtr) -> u64 {
     let mut stack: Vec<u64> = vec![];
     let mut op_stack = vec![Op::Traverse(n)];
+    let mut cache = HashMap::<NodePtr, u64>::new();
 
     while let Some(op) = op_stack.pop() {
         match op {
-            Op::Cons => {
+            Op::Cons(node) => {
                 let right = stack.pop().expect("internal error, empty stack");
                 let left = stack.pop().expect("internal error, empty stack");
-                stack.push(1 + left + right);
+                match cache.entry(node) {
+                    Entry::Occupied(e) => stack.push(*e.get()),
+                    Entry::Vacant(e) => {
+                        e.insert(1 + left + right);
+                        stack.push(1 + left + right);
+                    }
+                }
             }
-            Op::Traverse(n) => match a.sexp(n) {
-                SExp::Pair(left, right) => {
-                    op_stack.push(Op::Cons);
-                    op_stack.push(Op::Traverse(left));
-                    op_stack.push(Op::Traverse(right));
-                }
-                SExp::Atom => {
-                    let ser_len = node_to_bytes(a, n)
-                        .expect("internal error, failed to serialize")
-                        .len() as u64;
-                    stack.push(ser_len);
-                }
+            Op::Traverse(node) => match cache.entry(node) {
+                Entry::Occupied(e) => stack.push(*e.get()),
+                Entry::Vacant(e) => match a.sexp(node) {
+                    SExp::Pair(left, right) => {
+                        op_stack.push(Op::Cons(node));
+                        op_stack.push(Op::Traverse(left));
+                        op_stack.push(Op::Traverse(right));
+                    }
+                    SExp::Atom => {
+                        let ser_len = node_to_bytes(a, node)
+                            .expect("internal error, failed to serialize")
+                            .len() as u64;
+                        e.insert(ser_len);
+                        stack.push(ser_len);
+                    }
+                },
             },
         }
     }
@@ -43,19 +56,47 @@ fn compute_serialized_len(a: &Allocator, n: NodePtr) -> u64 {
     *stack.last().expect("internal error, empty stack")
 }
 
+fn pick_node(a: &Allocator, root: NodePtr, mut node_idx: i32) -> NodePtr {
+    let mut stack = vec![root];
+    let mut seen_node = HashSet::<NodePtr>::new();
+
+    while let Some(node) = stack.pop() {
+        if node_idx == 0 {
+            return node;
+        }
+        if !seen_node.insert(node) {
+            continue;
+        }
+        node_idx -= 1;
+        if let SExp::Pair(left, right) = a.sexp(node) {
+            stack.push(left);
+            stack.push(right);
+        }
+    }
+    NodePtr::NIL
+}
+
 fuzz_target!(|data: &[u8]| {
     let mut unstructured = arbitrary::Unstructured::new(data);
     let mut allocator = Allocator::new();
-    let program = make_tree::make_tree(&mut allocator, &mut unstructured);
+    let (tree, node_count) =
+        make_tree::make_tree_limits(&mut allocator, &mut unstructured, 10_000, true);
 
     let mut hash_cache = ObjectCache::new(treehash);
     let mut length_cache = ObjectCache::new(serialized_length);
-    visit_tree(&allocator, program, |a, node| {
-        let expect_hash = tree_hash(a, node);
-        let expect_len = compute_serialized_len(a, node);
-        let computed_hash = hash_cache.get_or_calculate(a, &node, None).unwrap();
-        let computed_len = length_cache.get_or_calculate(a, &node, None).unwrap();
-        assert_eq!(computed_hash, &expect_hash);
-        assert_eq!(computed_len, &expect_len);
-    });
+
+    let node_idx = unstructured.int_in_range(0..=node_count).unwrap_or(5) as i32;
+
+    let node = pick_node(&allocator, tree, node_idx);
+
+    let expect_hash = tree_hash(&allocator, node);
+    let expect_len = compute_serialized_len(&allocator, node);
+    let computed_hash = hash_cache
+        .get_or_calculate(&allocator, &node, None)
+        .unwrap();
+    let computed_len = length_cache
+        .get_or_calculate(&allocator, &node, None)
+        .unwrap();
+    assert_eq!(computed_hash, &expect_hash);
+    assert_eq!(computed_len, &expect_len);
 });

--- a/fuzz/fuzz_targets/serializer.rs
+++ b/fuzz/fuzz_targets/serializer.rs
@@ -14,7 +14,7 @@ use libfuzzer_sys::fuzz_target;
 fuzz_target!(|data: &[u8]| {
     let mut unstructured = arbitrary::Unstructured::new(data);
     let mut allocator = Allocator::new();
-    let program = make_tree::make_tree(&mut allocator, &mut unstructured);
+    let (program, _) = make_tree::make_tree(&mut allocator, &mut unstructured);
 
     let b1 = node_to_bytes_backrefs(&allocator, program).unwrap();
 


### PR DESCRIPTION
There's a performance problem in `insert_sentinel()` if it's passed a tree that is large because it reuses sub-trees. This case can cause the iteration to pick every tree node to run for a very long time. This change makes `insert_sentinel()` only consider nodes once, and skips them the second time they're encountered.

Without this change the fuzzer can time out.