### PR TITLE
Update rustfmt/clippy test job to Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -162,7 +162,7 @@ jobs:
           skip-existing: true
 
   checks:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Checks
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Update motivated by GitHub's deprecation of the 20.04 image. Notice text here:

```
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:

March 4 14:00 UTC – 22:00 UTC
March 11 13:00 UTC – 21:00 UTC
March 18 13:00 UTC – 21:00 UTC
March 25 13:00 UTC – 21:00 UTC
```