### PR TITLE
tie-break in favor of back-references

### DIFF
--- a/fuzz/fuzz_targets/serializer_cmp.rs
+++ b/fuzz/fuzz_targets/serializer_cmp.rs
@@ -63,7 +63,7 @@ pub fn compare_back_references(allocator: &Allocator, node: NodePtr) -> io::Resu
                     temp.write_all(&[BACK_REFERENCE])?;
                     write_atom(&mut temp, &path)?;
                     let temp = temp.into_inner();
-                    assert!(temp.len() < node_serialized_length as usize);
+                    assert!(temp.len() <= node_serialized_length as usize);
                 }
             }
             None => match allocator.sexp(node_to_write) {


### PR DESCRIPTION
allow back-reference paths to encode to the same number of bytes as the node it's referencing.

The rationale is that deduplicating nodes have more benefits than just saving space, it may also makes it cheaper to compute tree hashes.