### PR TITLE
factor out parts of the fuzzers into separate files

### DIFF
--- a/fuzz/fuzz_targets/object_cache.rs
+++ b/fuzz/fuzz_targets/object_cache.rs
@@ -1,80 +1,14 @@
 #![no_main]
 mod fuzzing_utils;
 mod make_tree;
+mod pick_node;
+mod serialized_len;
 
-use clvmr::serde::{node_to_bytes, serialized_length, treehash, ObjectCache};
-use clvmr::{Allocator, NodePtr, SExp};
+use clvmr::serde::{serialized_length, treehash, ObjectCache};
+use clvmr::Allocator;
 use fuzzing_utils::tree_hash;
 use libfuzzer_sys::fuzz_target;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
-use std::collections::HashSet;
-
-enum Op {
-    Cons(NodePtr),
-    Traverse(NodePtr),
-}
-
-fn compute_serialized_len(a: &Allocator, n: NodePtr) -> u64 {
-    let mut stack: Vec<u64> = vec![];
-    let mut op_stack = vec![Op::Traverse(n)];
-    let mut cache = HashMap::<NodePtr, u64>::new();
-
-    while let Some(op) = op_stack.pop() {
-        match op {
-            Op::Cons(node) => {
-                let right = stack.pop().expect("internal error, empty stack");
-                let left = stack.pop().expect("internal error, empty stack");
-                match cache.entry(node) {
-                    Entry::Occupied(e) => stack.push(*e.get()),
-                    Entry::Vacant(e) => {
-                        e.insert(1 + left + right);
-                        stack.push(1 + left + right);
-                    }
-                }
-            }
-            Op::Traverse(node) => match cache.entry(node) {
-                Entry::Occupied(e) => stack.push(*e.get()),
-                Entry::Vacant(e) => match a.sexp(node) {
-                    SExp::Pair(left, right) => {
-                        op_stack.push(Op::Cons(node));
-                        op_stack.push(Op::Traverse(left));
-                        op_stack.push(Op::Traverse(right));
-                    }
-                    SExp::Atom => {
-                        let ser_len = node_to_bytes(a, node)
-                            .expect("internal error, failed to serialize")
-                            .len() as u64;
-                        e.insert(ser_len);
-                        stack.push(ser_len);
-                    }
-                },
-            },
-        }
-    }
-    assert_eq!(stack.len(), 1);
-    *stack.last().expect("internal error, empty stack")
-}
-
-fn pick_node(a: &Allocator, root: NodePtr, mut node_idx: i32) -> NodePtr {
-    let mut stack = vec![root];
-    let mut seen_node = HashSet::<NodePtr>::new();
-
-    while let Some(node) = stack.pop() {
-        if node_idx == 0 {
-            return node;
-        }
-        if !seen_node.insert(node) {
-            continue;
-        }
-        node_idx -= 1;
-        if let SExp::Pair(left, right) = a.sexp(node) {
-            stack.push(left);
-            stack.push(right);
-        }
-    }
-    NodePtr::NIL
-}
+use serialized_len::compute_serialized_len;
 
 fuzz_target!(|data: &[u8]| {
     let mut unstructured = arbitrary::Unstructured::new(data);
@@ -86,8 +20,7 @@ fuzz_target!(|data: &[u8]| {
     let mut length_cache = ObjectCache::new(serialized_length);
 
     let node_idx = unstructured.int_in_range(0..=node_count).unwrap_or(5) as i32;
-
-    let node = pick_node(&allocator, tree, node_idx);
+    let node = pick_node::pick_node(&allocator, tree, node_idx);
 
     let expect_hash = tree_hash(&allocator, node);
     let expect_len = compute_serialized_len(&allocator, node);

--- a/fuzz/fuzz_targets/pick_node.rs
+++ b/fuzz/fuzz_targets/pick_node.rs
@@ -1,0 +1,22 @@
+use clvmr::{Allocator, NodePtr, SExp};
+use std::collections::HashSet;
+
+pub fn pick_node(a: &Allocator, root: NodePtr, mut node_idx: i32) -> NodePtr {
+    let mut stack = vec![root];
+    let mut seen_node = HashSet::<NodePtr>::new();
+
+    while let Some(node) = stack.pop() {
+        if node_idx == 0 {
+            return node;
+        }
+        if !seen_node.insert(node) {
+            continue;
+        }
+        node_idx -= 1;
+        if let SExp::Pair(left, right) = a.sexp(node) {
+            stack.push(left);
+            stack.push(right);
+        }
+    }
+    NodePtr::NIL
+}

--- a/fuzz/fuzz_targets/serialized_len.rs
+++ b/fuzz/fuzz_targets/serialized_len.rs
@@ -1,0 +1,50 @@
+use clvmr::serde::node_to_bytes;
+use clvmr::{Allocator, NodePtr, SExp};
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+
+enum Op {
+    Cons(NodePtr),
+    Traverse(NodePtr),
+}
+
+pub fn compute_serialized_len(a: &Allocator, n: NodePtr) -> u64 {
+    let mut stack: Vec<u64> = vec![];
+    let mut op_stack = vec![Op::Traverse(n)];
+    let mut cache = HashMap::<NodePtr, u64>::new();
+
+    while let Some(op) = op_stack.pop() {
+        match op {
+            Op::Cons(node) => {
+                let right = stack.pop().expect("internal error, empty stack");
+                let left = stack.pop().expect("internal error, empty stack");
+                match cache.entry(node) {
+                    Entry::Occupied(e) => stack.push(*e.get()),
+                    Entry::Vacant(e) => {
+                        e.insert(1 + left + right);
+                        stack.push(1 + left + right);
+                    }
+                }
+            }
+            Op::Traverse(node) => match cache.entry(node) {
+                Entry::Occupied(e) => stack.push(*e.get()),
+                Entry::Vacant(e) => match a.sexp(node) {
+                    SExp::Pair(left, right) => {
+                        op_stack.push(Op::Cons(node));
+                        op_stack.push(Op::Traverse(left));
+                        op_stack.push(Op::Traverse(right));
+                    }
+                    SExp::Atom => {
+                        let ser_len = node_to_bytes(a, node)
+                            .expect("internal error, failed to serialize")
+                            .len() as u64;
+                        e.insert(ser_len);
+                        stack.push(ser_len);
+                    }
+                },
+            },
+        }
+    }
+    assert_eq!(stack.len(), 1);
+    *stack.last().expect("internal error, empty stack")
+}

--- a/src/serde/ser_br.rs
+++ b/src/serde/ser_br.rs
@@ -63,7 +63,7 @@ pub fn node_to_stream_backrefs<W: io::Write>(
                 }
             },
         }
-        while !read_op_stack.is_empty() && read_op_stack[read_op_stack.len() - 1] == ReadOp::Cons {
+        while let Some(ReadOp::Cons) = read_op_stack.last() {
             read_op_stack.pop();
             read_cache_lookup.pop2_and_cons();
         }


### PR DESCRIPTION
since we don't have a "fuzzer utils" crate yet, these functions are individual modules included in the fuzzers directly. If we put them in the same file, we can get warnings for dead code if we don't use all the functions.