### PR TITLE
[CHIA-2679] remove ENABLE_KECCAK flag, since this softfork has activated

### DIFF
--- a/src/chia_dialect.rs
+++ b/src/chia_dialect.rs
@@ -29,10 +29,6 @@ pub const LIMIT_HEAP: u32 = 0x0004;
 // This is a hard-fork and should only be enabled when it activates
 pub const ENABLE_KECCAK_OPS_OUTSIDE_GUARD: u32 = 0x0100;
 
-// enables the keccak softfork extension. This is a soft-fork and
-// should be set for blocks past the activation height.
-pub const ENABLE_KECCAK: u32 = 0x0200;
-
 // The default mode when running grnerators in mempool-mode (i.e. the stricter
 // mode)
 pub const MEMPOOL_MODE: u32 = NO_UNKNOWN_OPS | LIMIT_HEAP;
@@ -195,9 +191,7 @@ impl Dialect for ChiaDialect {
             0 => OperatorSet::Bls,
 
             // Extension 1 is for the keccak256 operator.
-            // This is only considered valid in the mempool if it's enabled with the flag.
-            // This is to prevent submission of spends with keccak until the softfork activates.
-            1 if (self.flags & ENABLE_KECCAK) != 0 => OperatorSet::Keccak,
+            1 => OperatorSet::Keccak,
 
             // Extensions 2 and beyond are considered invalid by the mempool.
             // However, all future extensions are valid in consensus mode and reserved for future softforks.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,9 +21,7 @@ pub use allocator::{Allocator, Atom, NodePtr, SExp};
 pub use chia_dialect::ChiaDialect;
 pub use run_program::run_program;
 
-pub use chia_dialect::{
-    ENABLE_KECCAK, ENABLE_KECCAK_OPS_OUTSIDE_GUARD, LIMIT_HEAP, MEMPOOL_MODE, NO_UNKNOWN_OPS,
-};
+pub use chia_dialect::{ENABLE_KECCAK_OPS_OUTSIDE_GUARD, LIMIT_HEAP, MEMPOOL_MODE, NO_UNKNOWN_OPS};
 
 #[cfg(feature = "counters")]
 pub use run_program::run_program_with_counters;


### PR DESCRIPTION
The KECCAK soft fork has activated. It's now safe to remove this flag. the new operator is always enabled under the softfork guard (1).