### PR TITLE
[CHIA-3002] optimize edge cases of concat

### DIFF
--- a/op-tests/test-more-ops.txt
+++ b/op-tests/test-more-ops.txt
@@ -620,7 +620,10 @@ strlen "the quick brown fox jumps over the lazy dogs" => 44 | 227
 
 concat ( "ab" ) => FAIL
 concat ( "ab" ) "1" => FAIL
+concat => "" | 142
 concat "" => "" | 277
+concat "" "" => "" | 412
+concat "" "" "" => "" | 547
 concat "abc" => "abc" | 316
 concat "a" => "a" | 290
 concat "a" "b" => "ab" | 438
@@ -632,6 +635,7 @@ concat 0x00 0x00 => 0x0000 | 438
 concat 0x00 0xff => 0x00ff | 438
 concat 0xbaad 0xf00d => 0xbaadf00d | 464
 concat "foo" "bar" => "foobar" | 490
+concat "" "a" "" => "a" | 560
 
 substr => FAIL
 substr "abc" => FAIL

--- a/src/more_ops.rs
+++ b/src/more_ops.rs
@@ -638,11 +638,15 @@ pub fn op_concat(a: &mut Allocator, mut input: NodePtr, max_cost: Cost) -> Respo
             cost + total_size as Cost * CONCAT_COST_PER_BYTE,
             max_cost,
         )?;
-        match a.sexp(arg) {
+        let len = match a.sexp(arg) {
             SExp::Pair(_, _) => return err(arg, "concat on list"),
-            SExp::Atom => total_size += a.atom_len(arg),
+            SExp::Atom => a.atom_len(arg),
         };
-        terms.push(arg);
+        if len > 0 {
+            // skip NIL arguments, as an optimization
+            total_size += len;
+            terms.push(arg);
+        }
     }
 
     cost += total_size as Cost * CONCAT_COST_PER_BYTE;


### PR DESCRIPTION
In the case where a single argument is passed to `concat`, we can return the same node. In the case where 0 arguments are passed to `concat`, we can return `NIL`. Any `NIL` arguments passed to `concat` can be omitted, funnelling those cases towards one of the previous edge cases.

The current implementation copies the bytes on the heap of the node into a new allocation, returning a new node pointing to that heap region. This wastes memory in the case of a single node.

However, we impose limits on node count and heap size. In order to make these optimizations maintain the same behavior , we need to account for optimized away heap space. This patch calls it `ghost_heap` and harmonizes the naming of the similar counters to `ghost_atoms` and `ghost_pairs`. Those also track atoms and pairs that count against the limit, but were optimized away.