### PR TITLE
node_from_bytes_backrefs_old()

### DIFF
--- a/fuzz/fuzz_targets/deserialize_br_rand_tree.rs
+++ b/fuzz/fuzz_targets/deserialize_br_rand_tree.rs
@@ -1,10 +1,12 @@
 #![no_main]
 
 mod make_tree;
+mod node_eq;
 
 use clvmr::allocator::Allocator;
-use clvmr::serde::node_from_bytes_backrefs;
-use clvmr::serde::node_to_bytes_backrefs;
+use clvmr::serde::{
+    node_from_bytes_backrefs, node_from_bytes_backrefs_old, node_to_bytes_backrefs,
+};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
@@ -16,9 +18,16 @@ fuzz_target!(|data: &[u8]| {
     let b1 = node_to_bytes_backrefs(&allocator, program).unwrap();
 
     let mut allocator = Allocator::new();
-    let program = node_from_bytes_backrefs(&mut allocator, &b1).unwrap();
+    let program = node_from_bytes_backrefs(&mut allocator, &b1).expect("node_from_bytes_backrefs");
+    let node_count = allocator.pair_count();
 
-    let b2 = node_to_bytes_backrefs(&allocator, program).unwrap();
+    let program_old =
+        node_from_bytes_backrefs_old(&mut allocator, &b1).expect("node_from_bytes_backrefs_old");
+    // check that the new implementation creates the same number of pair nodes as the old one
+    assert_eq!(node_count * 2, allocator.pair_count());
+    assert!(node_eq::node_eq(&allocator, program, program_old));
+
+    let b2 = node_to_bytes_backrefs(&allocator, program).expect("node_to_bytes_backrefs");
     if b1 != b2 {
         panic!("b1 and b2 do not match");
     }


### PR DESCRIPTION
check fidelity between `node_from_bytes_backrefs()` and `node_from_bytes_backrefs_old()` in more positive cases.

This is to be able to remove it entirely in the future, with confidence.