### PR TITLE
remove `node_from_bytes_backrefs_record()`

### DIFF
--- a/src/serde/de_br.rs
+++ b/src/serde/de_br.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::io;
 use std::io::{Cursor, Read};
 
@@ -121,18 +120,6 @@ pub fn node_from_bytes_backrefs(allocator: &mut Allocator, b: &[u8]) -> io::Resu
 pub fn node_from_bytes_backrefs_old(allocator: &mut Allocator, b: &[u8]) -> io::Result<NodePtr> {
     let mut buffer = Cursor::new(b);
     node_from_stream_backrefs_old(allocator, &mut buffer, |_node| {})
-}
-
-pub fn node_from_bytes_backrefs_record(
-    allocator: &mut Allocator,
-    b: &[u8],
-) -> io::Result<(NodePtr, HashSet<NodePtr>)> {
-    let mut buffer = Cursor::new(b);
-    let mut backrefs = HashSet::<NodePtr>::new();
-    let ret = node_from_stream_backrefs(allocator, &mut buffer, |node| {
-        backrefs.insert(node);
-    })?;
-    Ok((ret, backrefs))
 }
 
 pub fn traverse_path_with_vec(
@@ -401,48 +388,5 @@ mod tests {
         assert!(traverse_path_with_vec(&mut a, &[0b1001], &mut list).is_err());
         assert!(traverse_path_with_vec(&mut a, &[0b1010], &mut list).is_err());
         assert!(traverse_path_with_vec(&mut a, &[0b1110], &mut list).is_err());
-    }
-
-    #[rstest]
-    // ("foobar" "foobar")
-    // no-backrefs
-    #[case("ff86666f6f626172ff86666f6f62617280", &[])]
-    // ("foobar" "foobar")
-    // with back-refs
-    #[case("ff86666f6f626172fe01", &["ff86666f6f62617280"])]
-    // ((1 2 3 4) 1 2 3 4)
-    // no-backrefs
-    #[case("ffff01ff02ff03ff0480ff01ff02ff03ff0480", &[])]
-    // ((1 2 3 4) 1 2 3 4)
-    // with back-refs
-    #[case("ffff01ff02ff03ff0480fe02", &["ff01ff02ff03ff0480"])]
-    // `(((((a_very_long_repeated_string . 1) .  (2 . 3)) . ((4 . 5) .  (6 . 7))) . (8 . 9)) 10 a_very_long_repeated_string)`
-    // no-backrefs
-    #[case("ffffffffff9b615f766572795f6c6f6e675f72657065617465645f737472696e6701ff0203ffff04\
-         05ff0607ff0809ff0aff9b615f766572795f6c6f6e675f72657065617465645f737472696e6780", &[])]
-    // with back-refs
-    #[case("ffffffffff9b615f766572795f6c6f6e675f72657065617465645f737472696e6701ff0203ffff0405ff0607ff0809ff0afffe4180",
-        &["9b615f766572795f6c6f6e675f72657065617465645f737472696e67"])]
-    fn test_deserialize_with_backrefs_record(
-        #[case] serialization_as_hex: &str,
-        #[case] expected_backrefs: &[&'static str],
-    ) {
-        use crate::serde::node_to_bytes;
-        let buf = Vec::from_hex(serialization_as_hex).unwrap();
-        let mut allocator = Allocator::new();
-        let (_node, backrefs) = node_from_bytes_backrefs_record(&mut allocator, &buf)
-            .expect("node_from_bytes_backrefs_records");
-        println!("backrefs: {:?}", backrefs);
-        assert_eq!(backrefs.len(), expected_backrefs.len());
-
-        let expected_backrefs =
-            HashSet::<String>::from_iter(expected_backrefs.iter().map(|s| s.to_string()));
-        let backrefs = HashSet::from_iter(
-            backrefs
-                .iter()
-                .map(|br| hex::encode(node_to_bytes(&allocator, *br).expect("node_to_bytes"))),
-        );
-
-        assert_eq!(backrefs, expected_backrefs);
     }
 }

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -23,9 +23,7 @@ mod test;
 
 pub use bitset::BitSet;
 pub use de::node_from_bytes;
-pub use de_br::{
-    node_from_bytes_backrefs, node_from_bytes_backrefs_old, node_from_bytes_backrefs_record,
-};
+pub use de_br::{node_from_bytes_backrefs, node_from_bytes_backrefs_old};
 pub use de_tree::{parse_triples, ParsedTriple};
 pub use identity_hash::RandomState;
 pub use incremental::{Serializer, UndoState};


### PR DESCRIPTION
as we have a simpler solution to memoizing tree_hash now