### PR TITLE
optimize debug allocator

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -22,8 +22,8 @@ const NODE_PTR_IDX_MASK: u32 = (1 << NODE_PTR_IDX_BITS) - 1;
 #[cfg(feature = "allocator-debug")]
 #[derive(Clone, Copy)]
 struct AllocatorReference {
-    fingerprint: u64,
-    version: usize,
+    fingerprint: u32,
+    version: u32,
 }
 
 #[cfg(feature = "allocator-debug")]
@@ -86,8 +86,8 @@ impl NodePtr {
         NodePtr(
             ((object_type as u32) << NODE_PTR_IDX_BITS) | (index as u32),
             AllocatorReference {
-                fingerprint: u64::MAX,
-                version: usize::MAX,
+                fingerprint: u32::MAX,
+                version: u32::MAX,
             },
         )
     }
@@ -246,11 +246,11 @@ pub struct Allocator {
     ghost_heap: usize,
 
     #[cfg(feature = "allocator-debug")]
-    fingerprint: u64,
+    fingerprint: u32,
 
     // the number of atoms and pairs at different versions
     #[cfg(feature = "allocator-debug")]
-    versions: Vec<(usize, usize)>,
+    versions: Vec<(u32, u32)>,
 }
 
 impl Default for Allocator {
@@ -322,7 +322,7 @@ impl Allocator {
             ghost_heap: 0,
 
             #[cfg(feature = "allocator-debug")]
-            fingerprint: rand::thread_rng().next_u64(),
+            fingerprint: rand::thread_rng().next_u32(),
 
             #[cfg(feature = "allocator-debug")]
             versions: Vec::new(),
@@ -335,7 +335,7 @@ impl Allocator {
 
     #[cfg(feature = "allocator-debug")]
     fn validate_node(&self, n: NodePtr) {
-        if n.1.fingerprint == u64::MAX && n.1.version == usize::MAX {
+        if n.1.fingerprint == u32::MAX && n.1.version == u32::MAX {
             assert!(matches!(n.object_type(), ObjectType::SmallAtom));
             return;
         }
@@ -346,19 +346,19 @@ impl Allocator {
         );
         // if n.1.version is equal to self.versions.len() it means no
         // restore_checkpoint() has been called since this NodePtr was created
-        if n.1.version < self.versions.len() {
+        if n.1.version < self.versions.len() as u32 {
             // self.versions contains the number of atoms (.0) and pairs (.1) at
             // the specific version
             match n.object_type() {
                 ObjectType::Bytes => {
                     assert!(
-                        (n.index() as usize) < self.versions[n.1.version].0,
+                        n.index() < self.versions[n.1.version as usize].0,
                         "NodePtr (atom) was invalidated by restore_checkpoint()"
                     );
                 }
                 ObjectType::Pair => {
                     assert!(
-                        (n.index() as usize) < self.versions[n.1.version].1,
+                        n.index() < self.versions[n.1.version as usize].1,
                         "NodePtr (pair) was invalidated by restore_checkpoint()"
                     );
                 }
@@ -381,7 +381,7 @@ impl Allocator {
             idx,
             AllocatorReference {
                 fingerprint: self.fingerprint,
-                version: self.versions.len(),
+                version: self.versions.len() as u32,
             },
         )
     }
@@ -419,7 +419,7 @@ impl Allocator {
         // lower version than self.versions.len()
         #[cfg(feature = "allocator-debug")]
         self.versions
-            .push((self.atom_vec.len(), self.pair_vec.len()));
+            .push((self.atom_vec.len() as u32, self.pair_vec.len() as u32));
     }
 
     pub fn new_atom(&mut self, v: &[u8]) -> Result<NodePtr, EvalErr> {

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -2112,7 +2112,7 @@ c6c886f6b57ec72a6178288c47c33577\
 
         // 0 is encoded as an empty string
         let num = number_from_u8(bytes);
-        assert_eq!(format!("{}", num), text);
+        assert_eq!(format!("{num}"), text);
         let ptr = a.new_number(num).unwrap();
         assert_eq!(a.atom(ptr).as_ref(), buf);
     }

--- a/src/serde/de_tree.rs
+++ b/src/serde/de_tree.rs
@@ -227,7 +227,7 @@ mod tests {
 
     fn check_parse_tree(h: &str, expected: Vec<ParsedTriple>, expected_sha_tree_hex: &str) {
         let b = Vec::from_hex(h).unwrap();
-        println!("{:?}", b);
+        println!("{b:?}");
         let mut f = Cursor::new(b);
         let (p, tree_hash) = parse_triples(&mut f, false).unwrap();
         assert_eq!(p, expected);

--- a/src/serde/tools.rs
+++ b/src/serde/tools.rs
@@ -187,7 +187,7 @@ fn is_canonical_atom(f: &mut Cursor<&[u8]>, first_byte: u8) -> bool {
         4 => 1 << (4 + 8 + 8),
         5 => 1 << (4 + 8 + 8 + 8),
         6 => 1 << (4 + 8 + 8 + 8 + 8),
-        _ => panic!("unexpected atom length prefix {}", prefix_len),
+        _ => panic!("unexpected atom length prefix {prefix_len}"),
     };
     if f.seek(SeekFrom::Current(atom_len as i64)).is_err() {
         return false;

--- a/src/test_ops.rs
+++ b/src/test_ops.rs
@@ -106,7 +106,7 @@ fn parse_atom(a: &mut Allocator, v: &str) -> NodePtr {
             "secp256r1_verify" => a.new_atom(&[0x1c, 0x3a, 0x8f, 0x00]).unwrap(),
             "keccak256" => a.new_atom(&[62]).unwrap(),
             _ => {
-                panic!("atom not supported \"{}\"", v);
+                panic!("atom not supported \"{v}\"");
             }
         }
     }

--- a/tools/src/bin/benchmark-clvm-cost.rs
+++ b/tools/src/bin/benchmark-clvm-cost.rs
@@ -295,9 +295,7 @@ struct Args {
 fn maybe_open(plot: bool, op: &str, name: &str) -> Box<dyn Write> {
     if plot {
         create_dir_all("measurements").expect("failed to create directory");
-        Box::new(
-            File::create(format!("measurements/{}-{}", op, name)).expect("failed to open file"),
-        )
+        Box::new(File::create(format!("measurements/{op}-{name}")).expect("failed to open file"))
     } else {
         Box::new(sink())
     }

--- a/wasm/src/run_program.rs
+++ b/wasm/src/run_program.rs
@@ -44,7 +44,7 @@ pub fn run_clvm(program: &[u8], args: &[u8], flag: u32) -> Vec<u8> {
     let r = run_program(&mut allocator, &dialect, program, args, max_cost);
     match r {
         Ok(reduction) => node_to_bytes(&allocator, reduction.1).unwrap(),
-        Err(_eval_err) => format!("{:?}", _eval_err).into(),
+        Err(_eval_err) => format!("{_eval_err:?}").into(),
     }
 }
 
@@ -77,6 +77,6 @@ pub fn run_chia_program(
             tuple.set(1, val);
             Ok(tuple)
         }
-        Err(_eval_err) => Err(format!("{:?}", _eval_err)),
+        Err(_eval_err) => Err(format!("{_eval_err:?}")),
     }
 }


### PR DESCRIPTION
make the `debug-allocator` feature use slightly less memory. Running generator stress tests uses gigabytes of memory with this feature enabled.