### PR TITLE
Add rustfmt and clippy to CI workflow

### DIFF
--- a/.github/workflows/build-crate.yml
+++ b/.github/workflows/build-crate.yml
@@ -28,10 +28,10 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: fmt (stable)
-        run: cargo +stable fmt --all -- --files-with-diff --check
+      - name: fmt
+        run: cargo fmt --all -- --files-with-diff --check
 
-      - name: clippy (stable)
+      - name: clippy
         run: cargo clippy --workspace --all-features --all-targets -- -D warnings
 
       - name: Install cargo-machete

--- a/.github/workflows/build-crate.yml
+++ b/.github/workflows/build-crate.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Set up rusts
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
 
       - name: fmt (stable)
         run: cargo +stable fmt --all -- --files-with-diff --check


### PR DESCRIPTION
Added rustfmt and clippy components to the Rust toolchain setup in the CI workflow.

addressing:
https://github.com/Chia-Network/clvm_rs/actions/runs/18014272944/job/51255303982#step:4:9
```
error: 'cargo-fmt' is not installed for the toolchain 'stable-x86_64-unknown-linux-gnu'.
To install, run `rustup component add rustfmt`
```

### Draft For:
- [ ] considering this instead https://github.com/Chia-Network/clvm_rs/pull/633