### PR TITLE
Prep for 0.17.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clvm-fuzzing"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -306,7 +306,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-rs-test-tools"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "bitflags",
  "chia-bls",
@@ -324,7 +324,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_rs"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "clvmr",
  "pyo3",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_rs-fuzz"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "arbitrary",
  "clvm-fuzzing",
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "bitflags",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["fuzz", "tools", "wheel", "clvm-fuzzing"]
 
 [package]
 name = "clvmr"
-version = "0.17.5"
+version = "0.17.6"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/clvm-fuzzing/Cargo.toml
+++ b/clvm-fuzzing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm-fuzzing"
-version = "0.17.5"
+version = "0.17.6"
 edition = "2024"
 license = "Apache-2.0"
 description = "Fuzzing tools for clvm Projects on Rust"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_rs-fuzz"
-version = "0.17.5"
+version = "0.17.6"
 authors = ["Arvid Norberg <arvid@chia.net>"]
 publish = false
 edition = "2024"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm-rs-test-tools"
-version = "0.17.5"
+version = "0.17.6"
 authors = ["Arvid Norberg <arvid@chia.net>", "Cameron Cooper <cameron@chia.net>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_rs"
-version = "0.17.5"
+version = "0.17.6"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this PR only bumps crate/package versions and updates `Cargo.lock`, with no functional or logic changes.
> 
> **Overview**
> Prepares the Rust workspace for the `0.17.6` release by bumping version numbers across `clvmr`, `clvm_rs`, `clvm-fuzzing`, `clvm_rs-fuzz`, and `clvm-rs-test-tools`.
> 
> Updates `Cargo.lock` to reflect the new `0.17.6` package versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45d03e13a9146c6384ad1518010c0d1af1071052. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->