### PR TITLE
publish on ubuntu-latest

### DIFF
--- a/.github/workflows/build-arm64-wheels.yml
+++ b/.github/workflows/build-arm64-wheels.yml
@@ -54,17 +54,20 @@ jobs:
           name: wheels
           path: target/wheels/
 
-      - name: Install setuptools_rust
-        run: |
-          if [ ! -f "venv" ]; then sudo rm -rf venv; fi
-          sudo apt-get install python3-venv python3-pip -y
-          python3 -m venv venv
-          if [ ! -f "activate" ]; then ln -s venv/bin/activate; fi
-          . ./activate
-          pip install setuptools_rust
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build_wheels
+    if: startsWith(github.event.ref, 'refs/tags')
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: wheels
+          path: target/wheels/
 
       - name: publish (PyPi)
-        if: startsWith(github.event.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: target/wheels/


### PR DESCRIPTION
According to https://github.com/pypa/gh-action-pypi-publish/issues/356

the publish workflow doesn't work on arm (how this worked before is a mystery - but it certainly doesn't work on the GH arm runners)

Create a seperate publish workflow on `ubuntu-latest`
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the release pipeline by moving PyPI publishing into a separate `ubuntu-latest` job that consumes build artifacts; misconfiguration could break tagged releases or publish incorrect artifacts.
> 
> **Overview**
> Build artifacts are now uploaded from the ARM64 wheel build job and **published to PyPI in a separate `publish` job** running on `ubuntu-latest`.
> 
> The old inline/extra setup step (installing `setuptools_rust`) is removed, and the publish job is gated to run only for tag refs via `startsWith(github.event.ref, 'refs/tags')`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82881a81c8e2d312a0e0c03f1a7ca33c3b155bf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->