### PR TITLE
prepare test_ops() to support more flags

### DIFF
--- a/src/test_ops.rs
+++ b/src/test_ops.rs
@@ -272,36 +272,34 @@ mod tests {
         }
     }
 
+    const NONE: ClvmFlags = ClvmFlags::empty();
+    const MALA: ClvmFlags = ClvmFlags::MALACHITE;
+
     #[rstest]
-    #[case("test-core-ops", false)]
-    #[case("test-more-ops", false)]
-    #[case("test-bls-ops", false)]
-    #[case("test-blspy-g1", false)]
-    #[case("test-blspy-g2", false)]
-    #[case("test-blspy-hash", false)]
-    #[case("test-blspy-pairing", false)]
-    #[case("test-blspy-verify", false)]
-    #[case("test-bls-zk", false)]
-    #[case("test-secp-verify", false)]
-    #[case("test-secp256k1", false)]
-    #[case("test-secp256r1", false)]
-    #[case("test-modpow", false)]
-    #[case("test-sha256", false)]
-    #[case("test-sha256tree", false)]
-    #[case("test-sha256tree-hash", false)]
-    #[case("test-keccak256", false)]
-    #[case("test-keccak256-generated", false)]
-    #[case("test-more-ops", true)]
-    #[case("test-modpow", true)]
-    fn test_ops(#[case] filename: &str, #[case] malachite: bool) {
+    #[case("test-core-ops", NONE)]
+    #[case("test-more-ops", NONE)]
+    #[case("test-more-ops", MALA)]
+    #[case("test-bls-ops", NONE)]
+    #[case("test-blspy-g1", NONE)]
+    #[case("test-blspy-g2", NONE)]
+    #[case("test-blspy-hash", NONE)]
+    #[case("test-blspy-pairing", NONE)]
+    #[case("test-blspy-verify", NONE)]
+    #[case("test-bls-zk", NONE)]
+    #[case("test-secp-verify", NONE)]
+    #[case("test-secp256k1", NONE)]
+    #[case("test-secp256r1", NONE)]
+    #[case("test-modpow", NONE)]
+    #[case("test-modpow", MALA)]
+    #[case("test-sha256", NONE)]
+    #[case("test-sha256tree", NONE)]
+    #[case("test-sha256tree-hash", NONE)]
+    #[case("test-keccak256", NONE)]
+    #[case("test-keccak256-generated", NONE)]
+    fn test_ops(#[case] filename: &str, #[case] flags: ClvmFlags) {
         use std::fs::read_to_string;
 
         let filename = format!("op-tests/{filename}.txt");
-        let flags = if malachite {
-            ClvmFlags::MALACHITE
-        } else {
-            ClvmFlags::empty()
-        };
 
         let funs = HashMap::from([
             ("i", op_if as Opf),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: test-only refactor that changes how `test_ops` is parameterized and adds additional flag variants, without affecting production execution paths.
> 
> **Overview**
> Refactors `test_ops` in `src/test_ops.rs` to take explicit `ClvmFlags` instead of a `malachite: bool`, introducing `NONE`/`MALA` constants for clearer flag selection.
> 
> Expands the rstest matrix to run `test-more-ops` and `test-modpow` under both default and `MALACHITE` flag configurations, preparing the test harness to support additional flags in the future.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 239c365f3b269aa207f0daa83ef6e5ca71f06c89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->