### PR TITLE
minor simplification of op_sha256

### DIFF
--- a/src/more_ops.rs
+++ b/src/more_ops.rs
@@ -386,15 +386,14 @@ pub fn op_sha256(
     if let Some([v0, v1]) = match_args::<2>(a, input)
         && a.small_number(v0) == Some(1)
         && let Some(val) = a.small_number(v1)
+        && (val as usize) < PRECOMPUTED_HASHES.len()
     {
         // in this case, we're hashing 1 concatenated with a small
         // integer, we may have a pre-computed hash for this
-        if (val as usize) < PRECOMPUTED_HASHES.len() {
-            let num_bytes: Cost = if val > 0 { 2 } else { 1 };
-            cost += num_bytes * SHA256_COST_PER_BYTE + 2 as Cost * SHA256_COST_PER_ARG;
-            check_cost(cost, max_cost)?;
-            return new_atom_and_cost(a, cost, &PRECOMPUTED_HASHES[val as usize]);
-        }
+        let num_bytes: Cost = if val > 0 { 2 } else { 1 };
+        cost += num_bytes * SHA256_COST_PER_BYTE + 2 as Cost * SHA256_COST_PER_ARG;
+        check_cost(cost, max_cost)?;
+        return new_atom_and_cost(a, cost, &PRECOMPUTED_HASHES[val as usize]);
     }
 
     let mut hasher = Sha256::new();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk refactor limited to `op_sha256` fastpath control flow; behavior should be unchanged aside from relying on the earlier bounds check to prevent out-of-range indexing.
> 
> **Overview**
> Simplifies `op_sha256`’s fastpath for hashing `1 || small-int` by moving the `PRECOMPUTED_HASHES` bounds check into the pattern guard and removing the redundant inner `if`, leaving the cost calculation and early return unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f95826dec016b48f3388a4118547ffb1c4a79e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->