### PR TITLE
docs: update stale release publishing note

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,4 +26,4 @@ $ git tag 0.1.20
 $ git push --tags
 ```
 
-The `0.1.20` tag on GitHub will cause the artifacts to be uploaded to crates.io, pypi.org and npmjs.com.
+The GitHub tag will trigger the official publication workflows for crates.io and PyPI.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,4 +26,4 @@ $ git tag 0.1.20
 $ git push --tags
 ```
 
-The GitHub tag will trigger the official publication workflows for crates.io and PyPI.
+The Git tag will trigger the official publication workflows for crates.io and PyPI.


### PR DESCRIPTION
This updates `RELEASE.md` to match the current repository workflows.

The file currently says a tag publishes to crates.io, PyPI, and npmjs.com, but this repository only has crates.io and PyPI publication workflows.

No code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change with no impact on runtime behavior or release automation itself.
> 
> **Overview**
> Clarifies `RELEASE.md` release instructions by updating the tagging note to reflect that a Git tag triggers publication workflows for **crates.io and PyPI only**, removing the outdated mention of npm publication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0760190e58ae77ea8734f448562dac0e1bfee27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->