### PR TITLE
Add min-release-age to prevent supply chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=1


### PR DESCRIPTION
See https://chia-network.atlassian.net/browse/SEC-1019 and #security_chat for context

## Summary

Adds `min-release-age=1` to `.npmrc`, which tells npm to only resolve package versions published more than 1 day ago. Most malicious package versions are detected and yanked within hours, so a 24-hour delay filters out smash-and-grab supply chain attacks.

This is primarily a Rust project, but npm is used for Prettier formatting. The setting protects those npm dependencies.

Requires npm >= 11.10.0 (ships with Node.js >= 24.14.1). Older npm versions silently ignore the setting.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single `.npmrc` setting change; primary impact is potential install friction on older npm versions or when needing same-day releases.
> 
> **Overview**
> Adds `min-release-age=1` to `.npmrc`, instructing npm to only resolve package versions published more than 24 hours ago to reduce exposure to smash-and-grab supply chain releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7da6e8207c12e758a1818a491b8ba7146785373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->