### PR TITLE
Fix benchmarks to exclude allocator-reset setup time from measurements

### DIFF
--- a/benches/deserialize.rs
+++ b/benches/deserialize.rs
@@ -23,7 +23,9 @@ fn deserialize_benchmark(c: &mut Criterion) {
         (compressed_block.as_ref(), "-compressed"),
     ] {
         group.bench_function(format!("serialized_length_from_bytes{name_suffix}"), |b| {
-            b.iter(|| black_box(serialized_length_from_bytes(bl).expect("serialized_length_from_bytes")))
+            b.iter(|| {
+                black_box(serialized_length_from_bytes(bl).expect("serialized_length_from_bytes"))
+            })
         });
 
         group.bench_function(

--- a/benches/deserialize.rs
+++ b/benches/deserialize.rs
@@ -4,9 +4,9 @@ use clvmr::serde::{
     node_to_bytes_backrefs, serialized_length_from_bytes, serialized_length_from_bytes_trusted,
     tree_hash_from_stream,
 };
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use std::include_bytes;
-use std::time::Instant;
+use std::time::Duration;
 
 fn deserialize_benchmark(c: &mut Criterion) {
     let block = include_bytes!("block_af9c3d98.bin");
@@ -23,21 +23,17 @@ fn deserialize_benchmark(c: &mut Criterion) {
         (compressed_block.as_ref(), "-compressed"),
     ] {
         group.bench_function(format!("serialized_length_from_bytes{name_suffix}"), |b| {
-            b.iter(|| {
-                let start = Instant::now();
-                serialized_length_from_bytes(bl).expect("serialized_length_from_bytes");
-                start.elapsed()
-            })
+            b.iter(|| black_box(serialized_length_from_bytes(bl).expect("serialized_length_from_bytes")))
         });
 
         group.bench_function(
             format!("serialized_length_from_bytes_trusted{name_suffix}"),
             |b| {
                 b.iter(|| {
-                    let start = Instant::now();
-                    serialized_length_from_bytes_trusted(bl)
-                        .expect("serialized_length_from_bytes_truested");
-                    start.elapsed()
+                    black_box(
+                        serialized_length_from_bytes_trusted(bl)
+                            .expect("serialized_length_from_bytes_trusted"),
+                    )
                 })
             },
         );
@@ -47,9 +43,7 @@ fn deserialize_benchmark(c: &mut Criterion) {
             group.bench_function(format!("tree_hash_from_stream{name_suffix}"), |b| {
                 b.iter(|| {
                     let mut cur = std::io::Cursor::new(*bl);
-                    let start = Instant::now();
-                    tree_hash_from_stream(&mut cur).expect("tree_hash_from_stream");
-                    start.elapsed()
+                    black_box(tree_hash_from_stream(&mut cur).expect("tree_hash_from_stream"))
                 })
             });
         }
@@ -58,20 +52,33 @@ fn deserialize_benchmark(c: &mut Criterion) {
         let iter_checkpoint = a.checkpoint();
 
         group.bench_function(format!("node_from_bytes_backrefs{name_suffix}"), |b| {
-            b.iter(|| {
-                a.restore_checkpoint(&iter_checkpoint);
-                let start = Instant::now();
-                node_from_bytes_backrefs(&mut a, bl).expect("node_from_bytes_backrefs");
-                start.elapsed()
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    a.restore_checkpoint(&iter_checkpoint);
+                    let start = std::time::Instant::now();
+                    black_box(
+                        node_from_bytes_backrefs(&mut a, bl).expect("node_from_bytes_backrefs"),
+                    );
+                    total += start.elapsed();
+                }
+                total
             })
         });
 
         group.bench_function(format!("node_from_bytes_backrefs_old{name_suffix}"), |b| {
-            b.iter(|| {
-                a.restore_checkpoint(&iter_checkpoint);
-                let start = Instant::now();
-                node_from_bytes_backrefs_old(&mut a, bl).expect("node_from_bytes_backrefs_old");
-                start.elapsed()
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    a.restore_checkpoint(&iter_checkpoint);
+                    let start = std::time::Instant::now();
+                    black_box(
+                        node_from_bytes_backrefs_old(&mut a, bl)
+                            .expect("node_from_bytes_backrefs_old"),
+                    );
+                    total += start.elapsed();
+                }
+                total
             })
         });
     }
@@ -79,11 +86,15 @@ fn deserialize_benchmark(c: &mut Criterion) {
     let mut a = Allocator::new();
     let iter_checkpoint = a.checkpoint();
     group.bench_function("node_from_bytes", |b| {
-        b.iter(|| {
-            a.restore_checkpoint(&iter_checkpoint);
-            let start = Instant::now();
-            node_from_bytes(&mut a, block).expect("node_from_bytes");
-            start.elapsed()
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            for _ in 0..iters {
+                a.restore_checkpoint(&iter_checkpoint);
+                let start = std::time::Instant::now();
+                black_box(node_from_bytes(&mut a, block).expect("node_from_bytes"));
+                total += start.elapsed();
+            }
+            total
         })
     });
 

--- a/benches/deserialize_2026.rs
+++ b/benches/deserialize_2026.rs
@@ -3,9 +3,9 @@ use clvmr::serde::node_from_bytes_backrefs;
 use clvmr::serde_2026::{deserialize_2026, serialize_2026};
 
 const BENCH_MAX_ATOM_LEN: usize = 1 << 20;
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use std::include_bytes;
-use std::time::Instant;
+use std::time::Duration;
 
 fn deserialize_2026_benchmark(c: &mut Criterion) {
     let blocks = [
@@ -27,12 +27,18 @@ fn deserialize_2026_benchmark(c: &mut Criterion) {
         let mut a = Allocator::new();
         let iter_checkpoint = a.checkpoint();
         group.bench_function(format!("deserialize_2026 {name}"), |b| {
-            b.iter(|| {
-                a.restore_checkpoint(&iter_checkpoint);
-                let start = Instant::now();
-                deserialize_2026(&mut a, &serialized_2026, BENCH_MAX_ATOM_LEN, false)
-                    .expect("deserialize_2026");
-                start.elapsed()
+            b.iter_custom(|iters| {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    a.restore_checkpoint(&iter_checkpoint);
+                    let start = std::time::Instant::now();
+                    black_box(
+                        deserialize_2026(&mut a, &serialized_2026, BENCH_MAX_ATOM_LEN, false)
+                            .expect("deserialize_2026"),
+                    );
+                    total += start.elapsed();
+                }
+                total
             })
         });
     }

--- a/benches/intern.rs
+++ b/benches/intern.rs
@@ -1,8 +1,7 @@
 use clvmr::allocator::Allocator;
 use clvmr::serde::{intern_tree, node_from_bytes, node_from_bytes_backrefs, node_to_bytes_limit};
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use std::include_bytes;
-use std::time::Instant;
 
 fn intern_benchmark(c: &mut Criterion) {
     let block0: &[u8] = include_bytes!("0.generator");
@@ -32,11 +31,7 @@ fn intern_benchmark(c: &mut Criterion) {
         };
 
         group.bench_function(format!("intern {name}"), |b| {
-            b.iter(|| {
-                let start = Instant::now();
-                let _tree = intern_tree(&a, node).expect("intern_tree");
-                start.elapsed()
-            })
+            b.iter(|| black_box(intern_tree(&a, node).expect("intern_tree")))
         });
     }
 

--- a/benches/serialize_2026.rs
+++ b/benches/serialize_2026.rs
@@ -1,10 +1,8 @@
 use clvmr::allocator::Allocator;
 use clvmr::serde::node_from_bytes_backrefs;
 use clvmr::serde_2026::serialize_2026;
-use criterion::black_box;
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use std::include_bytes;
-use std::time::Instant;
 
 fn serialize_2026_benchmark(c: &mut Criterion) {
     let generators = [
@@ -22,11 +20,7 @@ fn serialize_2026_benchmark(c: &mut Criterion) {
         let node = node_from_bytes_backrefs(&mut a, block).expect("node_from_bytes_backrefs");
 
         group.bench_function(format!("serialize_2026 {name}"), |b| {
-            b.iter(|| {
-                let start = Instant::now();
-                black_box(serialize_2026(&a, node, 0).expect("serialize_2026"));
-                start.elapsed()
-            })
+            b.iter(|| black_box(serialize_2026(&a, node, 0).expect("serialize_2026")))
         });
     }
 


### PR DESCRIPTION
## Summary

Benchmarks in `deserialize.rs`, `deserialize_2026.rs`, `serialize_2026.rs`, and `intern.rs` were incorrectly measuring setup time (allocator checkpoint restoration) as part of the benchmark, and manually calling `Instant::now()` / `start.elapsed()` which Criterion ignores entirely.

### Changes

- **`deserialize.rs` / `deserialize_2026.rs`**: Switch to `b.iter_custom()` so `a.restore_checkpoint()` runs *before* `Instant::now()` each iteration — only the deserialization itself is timed.
- **`serialize_2026.rs` / `intern.rs`**: Switch to `b.iter(|| black_box(...))` — these have no per-iteration setup, so the manual `Instant` timing was just dead code.
- Remove unused `std::time::Instant` imports throughout.

### Why this matters

Criterion's `b.iter()` manages its own timing; any `Instant` created inside the closure is ignored for measurement purposes. The old code appeared to measure correctly but was actually timing nothing useful — Criterion was just counting iterations with its own clock, which included the `restore_checkpoint()` overhead.

## Test plan

- [ ] `cargo bench --bench deserialize` produces stable, lower times than before
- [ ] `cargo test` still passes
- [ ] CI green

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect benchmark harness timing/measurement logic and imports, not library runtime behavior. Main risk is slightly altered benchmark methodology/results rather than functional regressions.
> 
> **Overview**
> Fixes Criterion benchmarks so they measure the intended work rather than allocator-reset/setup overhead.
> 
> In `deserialize.rs` and `deserialize_2026.rs`, switches deserialization benches to `b.iter_custom()` to time only the deserialization step while resetting the allocator outside the timed region. In `serialize_2026.rs` and `intern.rs`, removes manual `Instant` timing and uses `black_box` inside `b.iter()` so Criterion’s own timing is used correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da4bd32ff898442881cc5451af8b9ff012cfc1ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->