### PR TITLE
[CHIA-4249] limit nesting depth of softfork in mempool mode

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -76,6 +76,9 @@ pub enum EvalErr {
 
     #[error("Secp256 Verify Error: failed")]
     Secp256Failed(NodePtr),
+
+    #[error("softfork stack depth exceeded")]
+    SoftforkStackDepthExceeded,
 }
 impl From<std::io::Error> for EvalErr {
     fn from(_: std::io::Error) -> Self {

--- a/src/run_program.rs
+++ b/src/run_program.rs
@@ -4,6 +4,7 @@ use super::traverse_path::traverse_path_fast;
 #[cfg(not(feature = "no-fastpath"))]
 use crate::allocator::NodeVisitor;
 use crate::allocator::{Allocator, Checkpoint, MaybeRestore, NodePtr, SExp, TransparentCheckpoint};
+use crate::chia_dialect::ClvmFlags;
 use crate::cost::Cost;
 use crate::dialect::{Dialect, OperatorSet};
 use crate::error::{EvalErr, Result};
@@ -410,6 +411,10 @@ impl<'a, D: Dialect> RunProgramContext<'a, D> {
                     return Err(err);
                 }
             };
+
+            if self.dialect.flags().contains(ClvmFlags::LIMITS) && self.softfork_stack.len() >= 20 {
+                return Err(EvalErr::SoftforkStackDepthExceeded);
+            }
 
             self.softfork_stack.push(SoftforkGuard {
                 expected_cost: current_cost + expected_cost,
@@ -1644,6 +1649,46 @@ mod tests {
             err,
         };
         run_test_case(&t);
+    }
+
+    fn build_nested_softfork(depth: usize) -> (String, Cost) {
+        let mut program = "(q . 42)".to_string();
+        let mut cost: Cost = QUOTE_COST;
+
+        for _ in 0..depth {
+            let softfork_param = GUARD_COST + cost;
+            program = format!("(softfork (q . {softfork_param}) (q . 0) (q . {program}) (q . ()))");
+            cost = OP_COST + 4 * QUOTE_COST + softfork_param;
+        }
+
+        (program, cost)
+    }
+
+    #[rstest]
+    #[case::at_limit_with_flag(20, ClvmFlags::LIMITS, "")]
+    #[case::over_limit_with_flag(21, ClvmFlags::LIMITS, "softfork stack depth exceeded")]
+    #[case::over_limit_without_flag(21, ClvmFlags::empty(), "")]
+    fn test_limit_softfork_stack(
+        #[case] depth: usize,
+        #[case] flags: ClvmFlags,
+        #[case] err: &str,
+    ) {
+        use crate::chia_dialect::ChiaDialect;
+
+        let (prg, cost) = build_nested_softfork(depth);
+        let mut a = Allocator::new();
+        let program = check(parse_exp(&mut a, &prg));
+        let args = check(parse_exp(&mut a, "()"));
+        let dialect = ChiaDialect::new(flags);
+        match run_program(&mut a, &dialect, program, args, cost) {
+            Ok(Reduction(actual_cost, _)) => {
+                assert_eq!(err, "");
+                assert_eq!(actual_cost, cost);
+            }
+            Err(e) => {
+                assert_eq!(e.to_string(), err);
+            }
+        }
     }
 
     #[cfg(feature = "counters")]


### PR DESCRIPTION
As a precaution. nesting 20 softfork invocations should be more than enough for a single puzzle.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mempool puzzle validation behavior for deeply nested softforks; consensus evaluation is unaffected but mempool may reject transactions that previously passed.
> 
> **Overview**
> Adds a **mempool-only guard** on nested `softfork` operators: when `ClvmFlags::LIMITS` is set (including default `MEMPOOL_MODE`), entering a 21st nested softfork returns **`softfork stack depth exceeded`** via new `EvalErr::SoftforkStackDepthExceeded`. Consensus paths without `LIMITS` are unchanged—deep nesting still runs.
> 
> Tests build nested softfork programs and assert depth 20 succeeds with `LIMITS`, depth 21 fails with the new error, and depth 21 without `LIMITS` still succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae5845e7de718531fbd0d310f5ead6174ac6eaa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->