### PR TITLE
bump version to 0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clvm-fuzzing"
-version = "0.17.7"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-rs-test-tools"
-version = "0.17.7"
+version = "0.18.0"
 dependencies = [
  "bitflags",
  "chia-bls",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_rs"
-version = "0.17.7"
+version = "0.18.0"
 dependencies = [
  "clvmr",
  "pyo3",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_rs-fuzz"
-version = "0.17.7"
+version = "0.18.0"
 dependencies = [
  "arbitrary",
  "clvm-fuzzing",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.17.7"
+version = "0.18.0"
 dependencies = [
  "bitflags",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["fuzz", "tools", "wheel", "clvm-fuzzing"]
 
 [package]
 name = "clvmr"
-version = "0.17.7"
+version = "0.18.0"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2024"
 license = "Apache-2.0"
@@ -45,8 +45,8 @@ lto = "thin"
 
 [workspace.dependencies]
 bitflags = "2.10"
-clvmr = { path = ".", version = "0.17.0" }
-clvm-fuzzing = { path = "./clvm-fuzzing", version = "0.17.0" }
+clvmr = { path = ".", version = "0.18.0" }
+clvm-fuzzing = { path = "./clvm-fuzzing", version = "0.18.0" }
 lazy_static = "1.5.0"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"

--- a/clvm-fuzzing/Cargo.toml
+++ b/clvm-fuzzing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm-fuzzing"
-version = "0.17.7"
+version = "0.18.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Fuzzing tools for clvm Projects on Rust"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_rs-fuzz"
-version = "0.17.7"
+version = "0.18.0"
 authors = ["Arvid Norberg <arvid@chia.net>"]
 publish = false
 edition = "2024"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm-rs-test-tools"
-version = "0.17.7"
+version = "0.18.0"
 authors = ["Arvid Norberg <arvid@chia.net>", "Cameron Cooper <cameron@chia.net>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_rs"
-version = "0.17.7"
+version = "0.18.0"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Metadata-only version changes with no runtime or logic modifications.
> 
> **Overview**
> Bumps the **clvm_rs** workspace release from **0.17.7** to **0.18.0** across all member crates and refreshes **Cargo.lock**.
> 
> The root `clvmr` package version and workspace dependency pins for `clvmr` and `clvm-fuzzing` move from **0.17.x** to **0.18.0**. The same version is applied to **clvm-fuzzing**, **clvm_rs-fuzz**, **clvm-rs-test-tools**, and the Python wheel crate **clvm_rs**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e4784d76014c0a67891d0c1daf009a27b903cdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->