### PR TITLE
bump version to 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clvm-fuzzing"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "clvm-rs-test-tools"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bitflags",
  "chia-bls",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_rs"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "clvmr",
  "pyo3",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "clvm_rs-fuzz"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "arbitrary",
  "clvm-fuzzing",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "clvmr"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bitflags",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arbitrary"
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["fuzz", "tools", "wheel", "clvm-fuzzing"]
 
 [package]
 name = "clvmr"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2024"
 license = "Apache-2.0"
@@ -45,8 +45,8 @@ lto = "thin"
 
 [workspace.dependencies]
 bitflags = "2.10"
-clvmr = { path = ".", version = "0.18.0" }
-clvm-fuzzing = { path = "./clvm-fuzzing", version = "0.18.0" }
+clvmr = { path = ".", version = "0.19.0" }
+clvm-fuzzing = { path = "./clvm-fuzzing", version = "0.19.0" }
 lazy_static = "1.5.0"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"

--- a/clvm-fuzzing/Cargo.toml
+++ b/clvm-fuzzing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm-fuzzing"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Fuzzing tools for clvm Projects on Rust"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_rs-fuzz"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Arvid Norberg <arvid@chia.net>"]
 publish = false
 edition = "2024"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm-rs-test-tools"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Arvid Norberg <arvid@chia.net>", "Cameron Cooper <cameron@chia.net>"]
 edition = "2024"
 license = "Apache-2.0"

--- a/wheel/Cargo.toml
+++ b/wheel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clvm_rs"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Richard Kiss <him@richardkiss.com>"]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and lockfile-only changes with no runtime or interpreter logic modifications.
> 
> **Overview**
> Bumps the **clvm_rs** workspace release from **0.18.0** to **0.19.0** across the root `clvmr` crate and related packages (`clvm-fuzzing`, `clvm-rs-test-tools`, `clvm_rs` wheel, `clvm_rs-fuzz`), including `workspace.dependencies` version pins.
> 
> `Cargo.lock` is updated to match those package versions and picks up minor transitive dependency revisions (`anyhow`, `crossbeam-epoch`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eecddf02228f844aff569dccfb1eaeeff752851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->