### PR TITLE
Update Managed Files

### DIFF
--- a/.github/workflows/check-commit-signing.yml
+++ b/.github/workflows/check-commit-signing.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow_ref, github.event.pull_request.number) || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only change that reduces token permissions; no application or security logic changes.
> 
> **Overview**
> Adds an explicit **`permissions: contents: read`** block to the **Check commit signing** GitHub Actions workflow so the job only gets the minimum access needed to check out the repo and run the signing check.
> 
> This matches the pattern used on other workflows in `.github/workflows` and is consistent with tightening default/workflow token scope rather than changing what the job does.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a5ea3ccbb7046de87961e48cf34c702a1daa3de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->