### PR TITLE
add unit tests for unknown operators

### DIFF
--- a/op-tests/test-unknown-ops-v2.txt
+++ b/op-tests/test-unknown-ops-v2.txt
@@ -1,0 +1,73 @@
+; Unknown operators (lenient mode) under NEW_COST_MODEL. Always return NIL.
+; cost_function is encoded in the top 2 bits of the last opcode byte:
+;   unknown         = 0 (constant cost)
+;   unknown_add     = 1 (add-like)
+;   unknown_mul     = 2 (mul-like)
+;   unknown_concat  = 3 (concat-like)
+; Names without a suffix use multiplier 0; *_x2 use multiplier 1 (cost *= 2).
+; Costs must not regress.
+
+; cost_function 0: ignores arguments (including pairs)
+unknown => ( ) | 1
+unknown 1 => ( ) | 1
+unknown 1 2 3 => ( ) | 1
+unknown ( 1 2 ) => ( ) | 1
+unknown "foobar" 0xabcd => ( ) | 1
+unknown_x2 => ( ) | 2
+unknown_x2 1 2 3 => ( ) | 2
+unknown_x2 ( 1 2 ) => ( ) | 2
+
+; cost_function 1: add-like (new cost model: max accumulator size)
+unknown_add => ( ) | 99
+unknown_add 1 => ( ) | 603
+unknown_add 0 => ( ) | 599
+unknown_add "" => ( ) | 599
+unknown_add 1 2 => ( ) | 1107
+unknown_add 1 2 3 4 => ( ) | 2115
+unknown_add 0x1234 0x56 => ( ) | 1115
+unknown_add "foobar" => ( ) | 623
+unknown_add 0x00 0x00 0x7f0000 0x00 => ( ) | 2131
+unknown_add 0x010000000000000000 0x010000000000000000 => ( ) | 1171
+unknown_add ( 1 ) => FAIL
+unknown_add 1 ( 2 ) => FAIL
+unknown_add_x2 => ( ) | 198
+unknown_add_x2 1 => ( ) | 1206
+unknown_add_x2 1 2 => ( ) | 2214
+unknown_add_x2 1 2 3 4 => ( ) | 4230
+unknown_add_x2 "foobar" => ( ) | 1246
+unknown_add_x2 ( 1 ) => FAIL
+
+; cost_function 2: mul-like (new cost model; first arg also pays linear byte cost)
+unknown_mul => ( ) | 2000
+unknown_mul 1 => ( ) | 2006
+unknown_mul 7 2 => ( ) | 2903
+unknown_mul 1 2 3 4 => ( ) | 4715
+unknown_mul "ab" "cd" => ( ) | 2921
+unknown_mul 0x010000 0x010000 => ( ) | 2939
+unknown_mul 0x000000000000000007 0x000000000000000002 => ( ) | 3052
+unknown_mul ( 1 ) => FAIL
+unknown_mul 1 ( 2 ) => FAIL
+unknown_mul_x2 => ( ) | 4000
+unknown_mul_x2 1 => ( ) | 4012
+unknown_mul_x2 7 2 => ( ) | 5806
+unknown_mul_x2 1 2 3 4 => ( ) | 9430
+unknown_mul_x2 "ab" "cd" => ( ) | 5842
+unknown_mul_x2 ( 1 ) => FAIL
+
+; cost_function 3: concat-like (same for old and new cost model)
+unknown_concat => ( ) | 142
+unknown_concat "" => ( ) | 277
+unknown_concat "a" => ( ) | 280
+unknown_concat "a" "b" => ( ) | 418
+unknown_concat "a" "b" "c" => ( ) | 556
+unknown_concat 0xff 0x00 => ( ) | 418
+unknown_concat "foo" "bar" => ( ) | 430
+unknown_concat "" "a" "" => ( ) | 550
+unknown_concat ( 1 ) => FAIL
+unknown_concat "a" ( 2 ) => FAIL
+unknown_concat_x2 => ( ) | 284
+unknown_concat_x2 "" => ( ) | 554
+unknown_concat_x2 "a" => ( ) | 560
+unknown_concat_x2 "a" "b" => ( ) | 836
+unknown_concat_x2 "foo" "bar" => ( ) | 860
+unknown_concat_x2 ( 1 ) => FAIL

--- a/op-tests/test-unknown-ops.txt
+++ b/op-tests/test-unknown-ops.txt
@@ -1,0 +1,73 @@
+; Unknown operators (lenient mode). Always return NIL.
+; cost_function is encoded in the top 2 bits of the last opcode byte:
+;   unknown         = 0 (constant cost)
+;   unknown_add     = 1 (add-like)
+;   unknown_mul     = 2 (mul-like)
+;   unknown_concat  = 3 (concat-like)
+; Names without a suffix use multiplier 0; *_x2 use multiplier 1 (cost *= 2).
+; Costs must not regress.
+
+; cost_function 0: ignores arguments (including pairs)
+unknown => ( ) | 1
+unknown 1 => ( ) | 1
+unknown 1 2 3 => ( ) | 1
+unknown ( 1 2 ) => ( ) | 1
+unknown "foobar" 0xabcd => ( ) | 1
+unknown_x2 => ( ) | 2
+unknown_x2 1 2 3 => ( ) | 2
+unknown_x2 ( 1 2 ) => ( ) | 2
+
+; cost_function 1: add-like (old cost model)
+unknown_add => ( ) | 99
+unknown_add 1 => ( ) | 422
+unknown_add 0 => ( ) | 419
+unknown_add "" => ( ) | 419
+unknown_add 1 2 => ( ) | 745
+unknown_add 1 2 3 4 => ( ) | 1391
+unknown_add 0x1234 0x56 => ( ) | 748
+unknown_add "foobar" => ( ) | 437
+unknown_add 0x00 0x00 0x7f0000 0x00 => ( ) | 1397
+unknown_add 0x010000000000000000 0x010000000000000000 => ( ) | 793
+unknown_add ( 1 ) => FAIL
+unknown_add 1 ( 2 ) => FAIL
+unknown_add_x2 => ( ) | 198
+unknown_add_x2 1 => ( ) | 844
+unknown_add_x2 1 2 => ( ) | 1490
+unknown_add_x2 1 2 3 4 => ( ) | 2782
+unknown_add_x2 "foobar" => ( ) | 874
+unknown_add_x2 ( 1 ) => FAIL
+
+; cost_function 2: mul-like (old cost model)
+unknown_mul => ( ) | 92
+unknown_mul 1 => ( ) | 92
+unknown_mul 7 2 => ( ) | 989
+unknown_mul 1 2 3 4 => ( ) | 2801
+unknown_mul "ab" "cd" => ( ) | 1001
+unknown_mul 0x010000 0x010000 => ( ) | 1013
+unknown_mul 0x000000000000000007 0x000000000000000002 => ( ) | 1085
+unknown_mul ( 1 ) => FAIL
+unknown_mul 1 ( 2 ) => FAIL
+unknown_mul_x2 => ( ) | 184
+unknown_mul_x2 1 => ( ) | 184
+unknown_mul_x2 7 2 => ( ) | 1978
+unknown_mul_x2 1 2 3 4 => ( ) | 5602
+unknown_mul_x2 "ab" "cd" => ( ) | 2002
+unknown_mul_x2 ( 1 ) => FAIL
+
+; cost_function 3: concat-like (same for old and new cost model)
+unknown_concat => ( ) | 142
+unknown_concat "" => ( ) | 277
+unknown_concat "a" => ( ) | 280
+unknown_concat "a" "b" => ( ) | 418
+unknown_concat "a" "b" "c" => ( ) | 556
+unknown_concat 0xff 0x00 => ( ) | 418
+unknown_concat "foo" "bar" => ( ) | 430
+unknown_concat "" "a" "" => ( ) | 550
+unknown_concat ( 1 ) => FAIL
+unknown_concat "a" ( 2 ) => FAIL
+unknown_concat_x2 => ( ) | 284
+unknown_concat_x2 "" => ( ) | 554
+unknown_concat_x2 "a" => ( ) | 560
+unknown_concat_x2 "a" "b" => ( ) | 836
+unknown_concat_x2 "foo" "bar" => ( ) | 860
+unknown_concat_x2 ( 1 ) => FAIL

--- a/src/test_ops.rs
+++ b/src/test_ops.rs
@@ -10,7 +10,7 @@ use crate::keccak256_ops::op_keccak256;
 use crate::more_ops::{
     op_add, op_all, op_any, op_ash, op_coinid, op_concat, op_div, op_divmod, op_gr, op_gr_bytes,
     op_logand, op_logior, op_lognot, op_logxor, op_lsh, op_mod, op_modpow, op_multiply, op_not,
-    op_point_add, op_pubkey_for_exp, op_sha256, op_strlen, op_substr, op_subtract,
+    op_point_add, op_pubkey_for_exp, op_sha256, op_strlen, op_substr, op_subtract, op_unknown,
 };
 use crate::number::Number;
 use crate::reduction::{Reduction, Response};
@@ -110,6 +110,17 @@ fn parse_atom(a: &mut Allocator, v: &str) -> NodePtr {
             "secp256r1_verify_65" => a.new_atom(&[65]).unwrap(),
             "keccak256" => a.new_atom(&[62]).unwrap(),
             "sha256tree" => a.new_atom(&[63]).unwrap(),
+
+            // synthetic names for the 4 unknown-op cost_function modes (multiplier 0)
+            "unknown" => a.new_atom(&[0x00]).unwrap(),
+            "unknown_add" => a.new_atom(&[0x40]).unwrap(),
+            "unknown_mul" => a.new_atom(&[0x80]).unwrap(),
+            "unknown_concat" => a.new_atom(&[0xc0]).unwrap(),
+            // same modes with multiplier 1 (cost *= 2)
+            "unknown_x2" => a.new_atom(&[0x01, 0x00]).unwrap(),
+            "unknown_add_x2" => a.new_atom(&[0x01, 0x40]).unwrap(),
+            "unknown_mul_x2" => a.new_atom(&[0x01, 0x80]).unwrap(),
+            "unknown_concat_x2" => a.new_atom(&[0x01, 0xc0]).unwrap(),
             _ => {
                 panic!("atom not supported \"{v}\"");
             }
@@ -247,6 +258,89 @@ mod tests {
         op_bls_g2_negate(a, input, max_cost, flags | ClvmFlags::RELAXED_BLS)
     }
 
+    // Unknown ops encode cost_function in the top 2 bits of the last opcode byte.
+    // Multiplier 0 wrappers: cost equals the length-based model.
+    // Multiplier 1 (_x2) wrappers: cost is doubled.
+    fn op_unknown_const(
+        a: &mut Allocator,
+        input: NodePtr,
+        max_cost: Cost,
+        flags: ClvmFlags,
+    ) -> Response {
+        let op = a.new_atom(&[0x00])?;
+        op_unknown(a, op, input, max_cost, flags)
+    }
+
+    fn op_unknown_add(
+        a: &mut Allocator,
+        input: NodePtr,
+        max_cost: Cost,
+        flags: ClvmFlags,
+    ) -> Response {
+        let op = a.new_atom(&[0x40])?;
+        op_unknown(a, op, input, max_cost, flags)
+    }
+
+    fn op_unknown_mul(
+        a: &mut Allocator,
+        input: NodePtr,
+        max_cost: Cost,
+        flags: ClvmFlags,
+    ) -> Response {
+        let op = a.new_atom(&[0x80])?;
+        op_unknown(a, op, input, max_cost, flags)
+    }
+
+    fn op_unknown_concat(
+        a: &mut Allocator,
+        input: NodePtr,
+        max_cost: Cost,
+        flags: ClvmFlags,
+    ) -> Response {
+        let op = a.new_atom(&[0xc0])?;
+        op_unknown(a, op, input, max_cost, flags)
+    }
+
+    fn op_unknown_const_x2(
+        a: &mut Allocator,
+        input: NodePtr,
+        max_cost: Cost,
+        flags: ClvmFlags,
+    ) -> Response {
+        let op = a.new_atom(&[0x01, 0x00])?;
+        op_unknown(a, op, input, max_cost, flags)
+    }
+
+    fn op_unknown_add_x2(
+        a: &mut Allocator,
+        input: NodePtr,
+        max_cost: Cost,
+        flags: ClvmFlags,
+    ) -> Response {
+        let op = a.new_atom(&[0x01, 0x40])?;
+        op_unknown(a, op, input, max_cost, flags)
+    }
+
+    fn op_unknown_mul_x2(
+        a: &mut Allocator,
+        input: NodePtr,
+        max_cost: Cost,
+        flags: ClvmFlags,
+    ) -> Response {
+        let op = a.new_atom(&[0x01, 0x80])?;
+        op_unknown(a, op, input, max_cost, flags)
+    }
+
+    fn op_unknown_concat_x2(
+        a: &mut Allocator,
+        input: NodePtr,
+        max_cost: Cost,
+        flags: ClvmFlags,
+    ) -> Response {
+        let op = a.new_atom(&[0x01, 0xc0])?;
+        op_unknown(a, op, input, max_cost, flags)
+    }
+
     // the input is a list of test cases, each item is a tuple of:
     // (function pointer to test, list of arguments, optional result)
     // if the result is None, the call is expected to fail
@@ -314,6 +408,8 @@ mod tests {
     #[case("test-keccak256-v2", NEW_COST)]
     #[case("test-keccak256-generated", NONE)]
     #[case("test-keccak256-generated-v2", NEW_COST)]
+    #[case("test-unknown-ops", NONE)]
+    #[case("test-unknown-ops-v2", NEW_COST)]
     fn test_ops(#[case] filename: &str, #[case] flags: ClvmFlags) {
         use std::fs::read_to_string;
 
@@ -372,6 +468,14 @@ mod tests {
             ("modpow", op_modpow as Opf),
             ("keccak256", op_keccak256 as Opf),
             ("sha256tree", op_sha256_tree as Opf),
+            ("unknown", op_unknown_const as Opf),
+            ("unknown_add", op_unknown_add as Opf),
+            ("unknown_mul", op_unknown_mul as Opf),
+            ("unknown_concat", op_unknown_concat as Opf),
+            ("unknown_x2", op_unknown_const_x2 as Opf),
+            ("unknown_add_x2", op_unknown_add_x2 as Opf),
+            ("unknown_mul_x2", op_unknown_mul_x2 as Opf),
+            ("unknown_concat_x2", op_unknown_concat_x2 as Opf),
         ]);
 
         println!("Test cases from: {filename}");


### PR DESCRIPTION
extend the operator test cases for some select unknown operators, to ensure they don't change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no modifications to `op_unknown` or production evaluation paths; risk is limited to test maintenance if expected costs change intentionally.
> 
> **Overview**
> Adds regression coverage for **lenient unknown operators** so their **NIL** results and **cost accounting** stay stable across cost-model changes.
> 
> New `op-tests/test-unknown-ops.txt` and `test-unknown-ops-v2.txt` exercise four **cost_function** modes (constant, add-like, mul-like, concat-like) plus `*_x2` **multiplier** variants, including **FAIL** when arguments contain pairs.
> 
> `test_ops.rs` wires synthetic opcode bytes into `op_unknown` via wrapper helpers and registers the new fixtures in the existing `test_ops` rstest matrix (default flags and `NEW_COST_MODEL`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bbac7d01d8d73b7e7c4818551df941a86f0cddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->